### PR TITLE
EIP1-7146: New OAVA comms templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 Spring Boot microservice that :
 - Provides an API for sending notifications using the [Government Notify](https://www.notifications.service.gov.uk/documentation) service.
 
+_**See section on [GOV.UK Notify Templates](templates/README.md) for details on creating and editing
+templates.**_
+
 ## Developer Setup
 ### Kotlin API Developers
 
@@ -210,6 +213,3 @@ classpath: /home/valtech/IdeaProjects/eip/eip-ero-voter-card-applications-api/sr
 context=ddl
 ```
 
-## Templates
-
-See section on [GOV.UK Notify Templates](templates/README.md)

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/dto/TemplatePersonalisationDto.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/dto/TemplatePersonalisationDto.kt
@@ -68,7 +68,6 @@ class ApplicationRejectedPersonalisationDto(
     applicationReference: String,
     firstName: String,
     eroContactDetails: ContactDetailsDto,
-    val sourceType: String,
     val rejectionReasonList: List<String>,
     val rejectionReasonMessage: String?,
 ) : BaseTemplatePersonalisationDto(

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/dto/TemplatePersonalisationDto.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/dto/TemplatePersonalisationDto.kt
@@ -3,7 +3,7 @@ package uk.gov.dluhc.notificationsapi.dto
 abstract class BaseTemplatePersonalisationDto(
     val applicationReference: String,
     val firstName: String,
-    val eroContactDetails: ContactDetailsDto
+    val eroContactDetails: ContactDetailsDto,
 )
 
 class IdDocumentPersonalisationDto(
@@ -11,22 +11,22 @@ class IdDocumentPersonalisationDto(
     firstName: String,
     eroContactDetails: ContactDetailsDto,
     val idDocumentRequestFreeText: String,
-    val documentRejectionText: String?
+    val documentRejectionText: String?,
 ) : BaseTemplatePersonalisationDto(
     applicationReference = applicationReference,
     firstName = firstName,
-    eroContactDetails = eroContactDetails
+    eroContactDetails = eroContactDetails,
 )
 
 class IdDocumentRequiredPersonalisationDto(
     applicationReference: String,
     firstName: String,
     eroContactDetails: ContactDetailsDto,
-    val idDocumentRequiredFreeText: String
+    val idDocumentRequiredFreeText: String,
 ) : BaseTemplatePersonalisationDto(
     applicationReference = applicationReference,
     firstName = firstName,
-    eroContactDetails = eroContactDetails
+    eroContactDetails = eroContactDetails,
 )
 
 class PhotoPersonalisationDto(
@@ -36,11 +36,11 @@ class PhotoPersonalisationDto(
     val photoRejectionReasons: List<String>,
     val photoRejectionNotes: String?,
     val photoRequestFreeText: String,
-    val uploadPhotoLink: String
+    val uploadPhotoLink: String,
 ) : BaseTemplatePersonalisationDto(
     applicationReference = applicationReference,
     firstName = firstName,
-    eroContactDetails = eroContactDetails
+    eroContactDetails = eroContactDetails,
 )
 
 class ApplicationApprovedPersonalisationDto(
@@ -50,74 +50,80 @@ class ApplicationApprovedPersonalisationDto(
 ) : BaseTemplatePersonalisationDto(
     applicationReference = applicationReference,
     firstName = firstName,
-    eroContactDetails = eroContactDetails
+    eroContactDetails = eroContactDetails,
 )
 
 class ApplicationReceivedPersonalisationDto(
     applicationReference: String,
     firstName: String,
     eroContactDetails: ContactDetailsDto,
+    val sourceType: String,
 ) : BaseTemplatePersonalisationDto(
     applicationReference = applicationReference,
     firstName = firstName,
-    eroContactDetails = eroContactDetails
+    eroContactDetails = eroContactDetails,
 )
 
 class ApplicationRejectedPersonalisationDto(
     applicationReference: String,
     firstName: String,
     eroContactDetails: ContactDetailsDto,
+    val sourceType: String,
     val rejectionReasonList: List<String>,
-    val rejectionReasonMessage: String?
+    val rejectionReasonMessage: String?,
 ) : BaseTemplatePersonalisationDto(
     applicationReference = applicationReference,
     firstName = firstName,
-    eroContactDetails = eroContactDetails
+    eroContactDetails = eroContactDetails,
 )
 
 class RejectedDocumentPersonalisationDto(
     applicationReference: String,
     firstName: String,
     eroContactDetails: ContactDetailsDto,
+    val sourceType: String,
     val documents: List<String>,
-    val rejectedDocumentFreeText: String?
+    val rejectedDocumentFreeText: String?,
 ) : BaseTemplatePersonalisationDto(
     applicationReference = applicationReference,
     firstName = firstName,
-    eroContactDetails = eroContactDetails
+    eroContactDetails = eroContactDetails,
 )
 
 class RejectedSignaturePersonalisationDto(
     applicationReference: String,
     firstName: String,
     eroContactDetails: ContactDetailsDto,
+    val sourceType: String,
     val rejectionNotes: String?,
     val rejectionReasons: List<String>,
     val rejectionFreeText: String?,
 ) : BaseTemplatePersonalisationDto(
     applicationReference = applicationReference,
     firstName = firstName,
-    eroContactDetails = eroContactDetails
+    eroContactDetails = eroContactDetails,
 )
 
 class RequestedSignaturePersonalisationDto(
     applicationReference: String,
     firstName: String,
     eroContactDetails: ContactDetailsDto,
+    val sourceType: String,
     val freeText: String?,
 ) : BaseTemplatePersonalisationDto(
     applicationReference = applicationReference,
     firstName = firstName,
-    eroContactDetails = eroContactDetails
+    eroContactDetails = eroContactDetails,
 )
 
 class NinoNotMatchedPersonalisationDto(
     applicationReference: String,
     firstName: String,
     eroContactDetails: ContactDetailsDto,
+    val sourceType: String,
     val additionalNotes: String?,
 ) : BaseTemplatePersonalisationDto(
     applicationReference = applicationReference,
     firstName = firstName,
-    eroContactDetails = eroContactDetails
+    eroContactDetails = eroContactDetails,
 )

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/ApplicationReceivedTemplatePreviewDtoMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/ApplicationReceivedTemplatePreviewDtoMapper.kt
@@ -1,13 +1,32 @@
 package uk.gov.dluhc.notificationsapi.mapper
 
 import org.mapstruct.Mapper
+import org.mapstruct.Mapping
+import uk.gov.dluhc.notificationsapi.dto.ApplicationReceivedPersonalisationDto
 import uk.gov.dluhc.notificationsapi.dto.ApplicationReceivedTemplatePreviewDto
+import uk.gov.dluhc.notificationsapi.dto.LanguageDto
+import uk.gov.dluhc.notificationsapi.models.BasePersonalisation
 import uk.gov.dluhc.notificationsapi.models.GenerateApplicationReceivedTemplatePreviewRequest
+import uk.gov.dluhc.notificationsapi.models.SourceType
 
 @Mapper(uses = [LanguageMapper::class, SourceTypeMapper::class])
-interface ApplicationReceivedTemplatePreviewDtoMapper {
+abstract class ApplicationReceivedTemplatePreviewDtoMapper {
 
-    fun toApplicationReceivedTemplatePreviewDto(
+    @Mapping(
+        target = "personalisation",
+        expression = "java( mapPersonalisation( language, request.getPersonalisation(), request.getSourceType() ) )"
+    )
+    abstract fun toApplicationReceivedTemplatePreviewDto(
         request: GenerateApplicationReceivedTemplatePreviewRequest
     ): ApplicationReceivedTemplatePreviewDto
+
+    @Mapping(
+        target = "sourceType",
+        expression = "java( sourceTypeMapper.toSourceTypeString( sourceType, languageDto ) )",
+    )
+    abstract fun mapPersonalisation(
+        languageDto: LanguageDto,
+        personalisation: BasePersonalisation,
+        sourceType: SourceType
+    ): ApplicationReceivedPersonalisationDto
 }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/ApplicationRejectedTemplatePreviewDtoMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/ApplicationRejectedTemplatePreviewDtoMapper.kt
@@ -8,6 +8,7 @@ import uk.gov.dluhc.notificationsapi.dto.ApplicationRejectedTemplatePreviewDto
 import uk.gov.dluhc.notificationsapi.dto.LanguageDto
 import uk.gov.dluhc.notificationsapi.models.ApplicationRejectedPersonalisation
 import uk.gov.dluhc.notificationsapi.models.GenerateApplicationRejectedTemplatePreviewRequest
+import uk.gov.dluhc.notificationsapi.models.SourceType
 
 @Mapper(uses = [LanguageMapper::class, SourceTypeMapper::class])
 abstract class ApplicationRejectedTemplatePreviewDtoMapper {
@@ -17,17 +18,22 @@ abstract class ApplicationRejectedTemplatePreviewDtoMapper {
 
     @Mapping(
         target = "personalisation",
-        expression = "java( mapPersonalisation( language, applicationRejectedTemplatePreviewRequest.getPersonalisation() ) )"
+        expression = "java( mapPersonalisation( language, request.getPersonalisation(), request.getSourceType() ) )"
     )
-    abstract fun toApplicationRejectedTemplatePreviewDto(applicationRejectedTemplatePreviewRequest: GenerateApplicationRejectedTemplatePreviewRequest): ApplicationRejectedTemplatePreviewDto
+    abstract fun toApplicationRejectedTemplatePreviewDto(request: GenerateApplicationRejectedTemplatePreviewRequest): ApplicationRejectedTemplatePreviewDto
 
+    @Mapping(
+        target = "sourceType",
+        expression = "java( sourceTypeMapper.toSourceTypeString( sourceType, languageDto ) )",
+    )
     @Mapping(
         target = "rejectionReasonList",
         expression = "java( mapApplicationRejectionReasons( languageDto, personalisation ) )"
     )
     abstract fun mapPersonalisation(
         languageDto: LanguageDto,
-        personalisation: ApplicationRejectedPersonalisation
+        personalisation: ApplicationRejectedPersonalisation,
+        sourceType: SourceType,
     ): ApplicationRejectedPersonalisationDto
 
     fun mapApplicationRejectionReasons(

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/ApplicationRejectedTemplatePreviewDtoMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/ApplicationRejectedTemplatePreviewDtoMapper.kt
@@ -8,7 +8,6 @@ import uk.gov.dluhc.notificationsapi.dto.ApplicationRejectedTemplatePreviewDto
 import uk.gov.dluhc.notificationsapi.dto.LanguageDto
 import uk.gov.dluhc.notificationsapi.models.ApplicationRejectedPersonalisation
 import uk.gov.dluhc.notificationsapi.models.GenerateApplicationRejectedTemplatePreviewRequest
-import uk.gov.dluhc.notificationsapi.models.SourceType
 
 @Mapper(uses = [LanguageMapper::class, SourceTypeMapper::class])
 abstract class ApplicationRejectedTemplatePreviewDtoMapper {
@@ -18,22 +17,17 @@ abstract class ApplicationRejectedTemplatePreviewDtoMapper {
 
     @Mapping(
         target = "personalisation",
-        expression = "java( mapPersonalisation( language, request.getPersonalisation(), request.getSourceType() ) )"
+        expression = "java( mapPersonalisation( language, applicationRejectedTemplatePreviewRequest.getPersonalisation() ) )"
     )
-    abstract fun toApplicationRejectedTemplatePreviewDto(request: GenerateApplicationRejectedTemplatePreviewRequest): ApplicationRejectedTemplatePreviewDto
+    abstract fun toApplicationRejectedTemplatePreviewDto(applicationRejectedTemplatePreviewRequest: GenerateApplicationRejectedTemplatePreviewRequest): ApplicationRejectedTemplatePreviewDto
 
-    @Mapping(
-        target = "sourceType",
-        expression = "java( sourceTypeMapper.toSourceTypeString( sourceType, languageDto ) )",
-    )
     @Mapping(
         target = "rejectionReasonList",
         expression = "java( mapApplicationRejectionReasons( languageDto, personalisation ) )"
     )
     abstract fun mapPersonalisation(
         languageDto: LanguageDto,
-        personalisation: ApplicationRejectedPersonalisation,
-        sourceType: SourceType,
+        personalisation: ApplicationRejectedPersonalisation
     ): ApplicationRejectedPersonalisationDto
 
     fun mapApplicationRejectionReasons(

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/NinoNotMatchedTemplatePreviewDtoMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/NinoNotMatchedTemplatePreviewDtoMapper.kt
@@ -2,14 +2,32 @@ package uk.gov.dluhc.notificationsapi.mapper
 
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping
+import uk.gov.dluhc.notificationsapi.dto.LanguageDto
+import uk.gov.dluhc.notificationsapi.dto.NinoNotMatchedPersonalisationDto
 import uk.gov.dluhc.notificationsapi.dto.NinoNotMatchedTemplatePreviewDto
 import uk.gov.dluhc.notificationsapi.models.GenerateNinoNotMatchedTemplatePreviewRequest
+import uk.gov.dluhc.notificationsapi.models.NinoNotMatchedPersonalisation
+import uk.gov.dluhc.notificationsapi.models.SourceType
 
 @Mapper(uses = [LanguageMapper::class, NotificationChannelMapper::class, SourceTypeMapper::class])
-interface NinoNotMatchedTemplatePreviewDtoMapper {
+abstract class NinoNotMatchedTemplatePreviewDtoMapper {
     @Mapping(
-        source = "request.personalisation.additionalNotes",
-        target = "personalisation.additionalNotes"
+        target = "personalisation",
+        expression = "java( mapPersonalisation( language, request.getPersonalisation(), request.getSourceType() ) )"
     )
-    fun toDto(request: GenerateNinoNotMatchedTemplatePreviewRequest): NinoNotMatchedTemplatePreviewDto
+    abstract fun toDto(request: GenerateNinoNotMatchedTemplatePreviewRequest): NinoNotMatchedTemplatePreviewDto
+
+    @Mapping(
+        target = "sourceType",
+        expression = "java( sourceTypeMapper.toSourceTypeString( sourceType, languageDto ) )",
+    )
+    @Mapping(
+        source = "personalisation.additionalNotes",
+        target = "additionalNotes"
+    )
+    abstract fun mapPersonalisation(
+        languageDto: LanguageDto,
+        personalisation: NinoNotMatchedPersonalisation,
+        sourceType: SourceType
+    ): NinoNotMatchedPersonalisationDto
 }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/RejectedDocumentTemplatePreviewDtoMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/RejectedDocumentTemplatePreviewDtoMapper.kt
@@ -8,6 +8,7 @@ import uk.gov.dluhc.notificationsapi.dto.RejectedDocumentPersonalisationDto
 import uk.gov.dluhc.notificationsapi.dto.RejectedDocumentTemplatePreviewDto
 import uk.gov.dluhc.notificationsapi.models.GenerateRejectedDocumentTemplatePreviewRequest
 import uk.gov.dluhc.notificationsapi.models.RejectedDocumentPersonalisation
+import uk.gov.dluhc.notificationsapi.models.SourceType
 
 @Mapper(uses = [LanguageMapper::class, SourceTypeMapper::class])
 abstract class RejectedDocumentTemplatePreviewDtoMapper {
@@ -17,16 +18,21 @@ abstract class RejectedDocumentTemplatePreviewDtoMapper {
 
     @Mapping(
         target = "personalisation",
-        expression = "java( mapPersonalisation( language, generateRejectedDocumentTemplatePreviewRequest.getPersonalisation() ) )"
+        expression = "java( mapPersonalisation( language, request.getPersonalisation(), request.getSourceType() ) )"
     )
-    abstract fun toRejectedDocumentTemplatePreviewDto(generateRejectedDocumentTemplatePreviewRequest: GenerateRejectedDocumentTemplatePreviewRequest): RejectedDocumentTemplatePreviewDto
+    abstract fun toRejectedDocumentTemplatePreviewDto(request: GenerateRejectedDocumentTemplatePreviewRequest): RejectedDocumentTemplatePreviewDto
 
+    @Mapping(
+        target = "sourceType",
+        expression = "java( sourceTypeMapper.toSourceTypeString( sourceType, languageDto ) )",
+    )
     @Mapping(
         target = "documents",
         expression = "java( rejectedDocumentsMapper.mapRejectionDocumentsFromApi( languageDto, personalisation.getDocuments() ) )"
     )
     abstract fun mapPersonalisation(
         languageDto: LanguageDto,
-        personalisation: RejectedDocumentPersonalisation
+        personalisation: RejectedDocumentPersonalisation,
+        sourceType: SourceType
     ): RejectedDocumentPersonalisationDto
 }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/RejectedDocumentsMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/RejectedDocumentsMapper.kt
@@ -2,6 +2,7 @@ package uk.gov.dluhc.notificationsapi.mapper
 
 import org.springframework.stereotype.Component
 import uk.gov.dluhc.notificationsapi.dto.LanguageDto
+import uk.gov.dluhc.notificationsapi.messaging.mapper.rejectionReasonsExcludingOther
 import uk.gov.dluhc.notificationsapi.messaging.models.RejectedDocument as RejectedDocumentMessaging
 import uk.gov.dluhc.notificationsapi.models.RejectedDocument as RejectedDocumentApi
 
@@ -10,6 +11,7 @@ class RejectedDocumentsMapper(
     private val rejectedDocumentReasonMapper: RejectedDocumentReasonMapper,
     private val rejectedDocumentTypeMapper: RejectedDocumentTypeMapper
 ) {
+    private val subItemSeparator = "\n  * "
 
     fun mapRejectionDocumentsFromApi(
         languageDto: LanguageDto,
@@ -17,8 +19,11 @@ class RejectedDocumentsMapper(
     ): List<String> {
         return documents.map { document ->
             val docType = rejectedDocumentTypeMapper.toDocumentTypeString(document.documentType, languageDto)
-            val docReason = document.rejectionReasons.combineReasons(languageDto, rejectedDocumentReasonMapper::toDocumentRejectionReasonString)
-            docType.appendIfNotNullOrEmpty(docReason).appendIfNotNullOrEmpty(document.rejectionNotes)
+            val docReason = document.rejectionReasonsExcludingOther
+                .combineReasons(languageDto, rejectedDocumentReasonMapper::toDocumentRejectionReasonString)
+            docType
+                .appendIfNotNullOrEmpty(docReason)
+                .appendIfNotNullOrEmpty(document.rejectionNotes)
         }
     }
 
@@ -28,13 +33,17 @@ class RejectedDocumentsMapper(
     ): List<String> {
         return documents.map { document ->
             val docType = rejectedDocumentTypeMapper.toDocumentTypeString(document.documentType, languageDto)
-            val docReason = document.rejectionReasons.combineReasons(languageDto, rejectedDocumentReasonMapper::toDocumentRejectionReasonString)
-            docType.appendIfNotNullOrEmpty(docReason).appendIfNotNullOrEmpty(document.rejectionNotes)
+            val docReason = document.rejectionReasonsExcludingOther
+                .combineReasons(languageDto, rejectedDocumentReasonMapper::toDocumentRejectionReasonString)
+            docType
+                .appendIfNotNullOrEmpty(docReason)
+                .appendIfNotNullOrEmpty(document.rejectionNotes)
         }
     }
 
     private fun <T> List<T>.combineReasons(language: LanguageDto, mapper: (T, LanguageDto) -> String) =
-        this.joinToString(separator = ", ") { mapper.invoke(it, language) }
+        this.joinToString(separator = subItemSeparator) { mapper.invoke(it, language) }
 
-    private fun String.appendIfNotNullOrEmpty(value: String?) = this + (" - $value".takeIf { !value.isNullOrEmpty() } ?: "")
+    private fun String.appendIfNotNullOrEmpty(value: String?) =
+        this + ((subItemSeparator + value).takeIf { !value.isNullOrEmpty() } ?: "")
 }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/RejectedSignatureTemplatePreviewDtoMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/RejectedSignatureTemplatePreviewDtoMapper.kt
@@ -9,6 +9,7 @@ import uk.gov.dluhc.notificationsapi.dto.RejectedSignaturePersonalisationDto
 import uk.gov.dluhc.notificationsapi.dto.RejectedSignatureTemplatePreviewDto
 import uk.gov.dluhc.notificationsapi.models.GenerateRejectedSignatureTemplatePreviewRequest
 import uk.gov.dluhc.notificationsapi.models.RejectedSignaturePersonalisation
+import uk.gov.dluhc.notificationsapi.models.SourceType
 
 @Mapper(uses = [LanguageMapper::class, NotificationChannelMapper::class, SourceTypeMapper::class])
 abstract class RejectedSignatureTemplatePreviewDtoMapper {
@@ -22,7 +23,7 @@ abstract class RejectedSignatureTemplatePreviewDtoMapper {
     )
     @Mapping(
         target = "personalisation",
-        expression = "java( mapPersonalisation( language, request.getPersonalisation() ) )"
+        expression = "java( mapPersonalisation( language, request.getPersonalisation(), request.getSourceType() ) )"
     )
     abstract fun toRejectedSignatureTemplatePreviewDto(
         request: GenerateRejectedSignatureTemplatePreviewRequest
@@ -38,12 +39,17 @@ abstract class RejectedSignatureTemplatePreviewDtoMapper {
         }
 
     @Mapping(
+        target = "sourceType",
+        expression = "java( sourceTypeMapper.toSourceTypeString( sourceType, languageDto ) )",
+    )
+    @Mapping(
         target = "rejectionReasons",
         expression = "java( mapSignatureRejectionReasons( languageDto, personalisation ) )"
     )
     protected abstract fun mapPersonalisation(
         languageDto: LanguageDto,
-        personalisation: RejectedSignaturePersonalisation
+        personalisation: RejectedSignaturePersonalisation,
+        sourceType: SourceType,
     ): RejectedSignaturePersonalisationDto
 
     protected fun mapSignatureRejectionReasons(

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/RequestedSignatureTemplatePreviewDtoMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/RequestedSignatureTemplatePreviewDtoMapper.kt
@@ -7,6 +7,7 @@ import uk.gov.dluhc.notificationsapi.dto.RequestedSignaturePersonalisationDto
 import uk.gov.dluhc.notificationsapi.dto.RequestedSignatureTemplatePreviewDto
 import uk.gov.dluhc.notificationsapi.models.GenerateRequestedSignatureTemplatePreviewRequest
 import uk.gov.dluhc.notificationsapi.models.RequestedSignaturePersonalisation
+import uk.gov.dluhc.notificationsapi.models.SourceType
 
 @Mapper(uses = [LanguageMapper::class, NotificationChannelMapper::class, SourceTypeMapper::class])
 abstract class RequestedSignatureTemplatePreviewDtoMapper {
@@ -17,14 +18,19 @@ abstract class RequestedSignatureTemplatePreviewDtoMapper {
     )
     @Mapping(
         target = "personalisation",
-        expression = "java( mapPersonalisation( language, request.getPersonalisation() ) )"
+        expression = "java( mapPersonalisation( language, request.getPersonalisation(), request.getSourceType() ) )"
     )
     abstract fun toRequestedSignatureTemplatePreviewDto(
         request: GenerateRequestedSignatureTemplatePreviewRequest
     ): RequestedSignatureTemplatePreviewDto
 
+    @Mapping(
+        target = "sourceType",
+        expression = "java( sourceTypeMapper.toSourceTypeString( sourceType, languageDto ) )",
+    )
     protected abstract fun mapPersonalisation(
         languageDto: LanguageDto,
-        personalisation: RequestedSignaturePersonalisation
+        personalisation: RequestedSignaturePersonalisation,
+        sourceType: SourceType,
     ): RequestedSignaturePersonalisationDto
 }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/SourceTypeMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/SourceTypeMapper.kt
@@ -3,22 +3,50 @@ package uk.gov.dluhc.notificationsapi.mapper
 import org.mapstruct.InheritInverseConfiguration
 import org.mapstruct.Mapper
 import org.mapstruct.ValueMapping
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.MessageSource
+import uk.gov.dluhc.notificationsapi.dto.LanguageDto
 import uk.gov.dluhc.notificationsapi.database.entity.SourceType as SourceTypeEntityEnum
 import uk.gov.dluhc.notificationsapi.dto.SourceType as SourceTypeDtoEnum
 import uk.gov.dluhc.notificationsapi.messaging.models.SourceType as SourceTypeMessageEnum
 import uk.gov.dluhc.notificationsapi.models.SourceType as SourceTypeApiEnum
 
 @Mapper
-interface SourceTypeMapper {
+abstract class SourceTypeMapper {
+
+    @Autowired
+    private lateinit var messageSource: MessageSource
 
     @ValueMapping(source = "VOTER_MINUS_CARD", target = "VOTER_CARD")
-    fun fromMessageToDto(sourceType: SourceTypeMessageEnum): SourceTypeDtoEnum
+    abstract fun fromMessageToDto(sourceType: SourceTypeMessageEnum): SourceTypeDtoEnum
 
-    fun fromDtoToEntity(sourceType: SourceTypeDtoEnum): SourceTypeEntityEnum
+    abstract fun fromDtoToEntity(sourceType: SourceTypeDtoEnum): SourceTypeEntityEnum
 
     @InheritInverseConfiguration
-    fun fromEntityToDto(sourceType: SourceTypeEntityEnum): SourceTypeDtoEnum
+    abstract fun fromEntityToDto(sourceType: SourceTypeEntityEnum): SourceTypeDtoEnum
 
     @ValueMapping(source = "VOTER_MINUS_CARD", target = "VOTER_CARD")
-    fun fromApiToDto(sourceType: SourceTypeApiEnum): SourceTypeDtoEnum
+    abstract fun fromApiToDto(sourceType: SourceTypeApiEnum): SourceTypeDtoEnum
+
+    fun toSourceTypeString(
+        sourceType: SourceTypeApiEnum,
+        languageDto: LanguageDto,
+    ): String {
+        return messageSource.getMessage(
+            "templates.vote-type.${sourceType.value}",
+            null,
+            languageDto.locale
+        )
+    }
+
+    fun toSourceTypeString(
+        sourceType: SourceTypeMessageEnum,
+        languageDto: LanguageDto,
+    ): String {
+        return messageSource.getMessage(
+            "templates.vote-type.${sourceType.value}",
+            null,
+            languageDto.locale
+        )
+    }
 }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/SourceTypeMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/SourceTypeMapper.kt
@@ -1,32 +1,46 @@
 package uk.gov.dluhc.notificationsapi.mapper
 
-import org.mapstruct.InheritInverseConfiguration
-import org.mapstruct.Mapper
-import org.mapstruct.ValueMapping
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.MessageSource
+import org.springframework.stereotype.Component
 import uk.gov.dluhc.notificationsapi.dto.LanguageDto
+import uk.gov.dluhc.notificationsapi.messaging.models.SourceType
 import uk.gov.dluhc.notificationsapi.database.entity.SourceType as SourceTypeEntityEnum
 import uk.gov.dluhc.notificationsapi.dto.SourceType as SourceTypeDtoEnum
 import uk.gov.dluhc.notificationsapi.messaging.models.SourceType as SourceTypeMessageEnum
 import uk.gov.dluhc.notificationsapi.models.SourceType as SourceTypeApiEnum
 
-@Mapper
-abstract class SourceTypeMapper {
+@Component
+class SourceTypeMapper(private val messageSource: MessageSource) {
 
-    @Autowired
-    private lateinit var messageSource: MessageSource
+    fun fromMessageToDto(sourceType: SourceTypeMessageEnum) = when (sourceType) {
+        SourceType.VOTER_MINUS_CARD -> SourceTypeDtoEnum.VOTER_CARD
+        SourceType.POSTAL -> SourceTypeDtoEnum.POSTAL
+        SourceType.PROXY -> SourceTypeDtoEnum.PROXY
+        SourceType.OVERSEAS -> SourceTypeDtoEnum.OVERSEAS
+    }
 
-    @ValueMapping(source = "VOTER_MINUS_CARD", target = "VOTER_CARD")
-    abstract fun fromMessageToDto(sourceType: SourceTypeMessageEnum): SourceTypeDtoEnum
+    fun fromDtoToEntity(sourceType: SourceTypeDtoEnum) = when (sourceType) {
+        SourceTypeDtoEnum.VOTER_CARD -> SourceTypeEntityEnum.VOTER_CARD
+        SourceTypeDtoEnum.POSTAL -> SourceTypeEntityEnum.POSTAL
+        SourceTypeDtoEnum.ANONYMOUS_ELECTOR_DOCUMENT -> SourceTypeEntityEnum.ANONYMOUS_ELECTOR_DOCUMENT
+        SourceTypeDtoEnum.PROXY -> SourceTypeEntityEnum.PROXY
+        SourceTypeDtoEnum.OVERSEAS -> SourceTypeEntityEnum.OVERSEAS
+    }
 
-    abstract fun fromDtoToEntity(sourceType: SourceTypeDtoEnum): SourceTypeEntityEnum
+    fun fromEntityToDto(sourceType: SourceTypeEntityEnum) = when (sourceType) {
+        SourceTypeEntityEnum.VOTER_CARD -> SourceTypeDtoEnum.VOTER_CARD
+        SourceTypeEntityEnum.POSTAL -> SourceTypeDtoEnum.POSTAL
+        SourceTypeEntityEnum.ANONYMOUS_ELECTOR_DOCUMENT -> SourceTypeDtoEnum.ANONYMOUS_ELECTOR_DOCUMENT
+        SourceTypeEntityEnum.PROXY -> SourceTypeDtoEnum.PROXY
+        SourceTypeEntityEnum.OVERSEAS -> SourceTypeDtoEnum.OVERSEAS
+    }
 
-    @InheritInverseConfiguration
-    abstract fun fromEntityToDto(sourceType: SourceTypeEntityEnum): SourceTypeDtoEnum
-
-    @ValueMapping(source = "VOTER_MINUS_CARD", target = "VOTER_CARD")
-    abstract fun fromApiToDto(sourceType: SourceTypeApiEnum): SourceTypeDtoEnum
+    fun fromApiToDto(sourceType: SourceTypeApiEnum) = when (sourceType) {
+        SourceTypeApiEnum.VOTER_MINUS_CARD -> SourceTypeDtoEnum.VOTER_CARD
+        SourceTypeApiEnum.POSTAL -> SourceTypeDtoEnum.POSTAL
+        SourceTypeApiEnum.PROXY -> SourceTypeDtoEnum.PROXY
+        SourceTypeApiEnum.OVERSEAS -> SourceTypeDtoEnum.OVERSEAS
+    }
 
     fun toSourceTypeString(
         sourceType: SourceTypeApiEnum,

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/TemplatePersonalisationDtoMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/TemplatePersonalisationDtoMapper.kt
@@ -90,7 +90,6 @@ class TemplatePersonalisationDtoMapper {
                 eroContactDetails.mapEroContactFields(this)
                 personalisation.putAll(this)
             }
-            personalisation["sourceType"] = sourceType
         }
         return personalisation
     }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/TemplatePersonalisationDtoMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/TemplatePersonalisationDtoMapper.kt
@@ -59,8 +59,19 @@ class TemplatePersonalisationDtoMapper {
         return personalisation
     }
 
-    fun toApplicationReceivedTemplatePersonalisationMap(dto: ApplicationReceivedPersonalisationDto): Map<String, String> {
-        return getBasicContactDetailsPersonalisationMap(dto)
+    fun toApplicationReceivedTemplatePersonalisationMap(dto: ApplicationReceivedPersonalisationDto): Map<String, Any> {
+        val personalisation = mutableMapOf<String, Any>()
+
+        with(dto) {
+            personalisation["applicationReference"] = applicationReference
+            personalisation["firstName"] = firstName
+            with(mutableMapOf<String, String>()) {
+                eroContactDetails.mapEroContactFields(this)
+                personalisation.putAll(this)
+            }
+            personalisation["sourceType"] = sourceType
+        }
+        return personalisation
     }
 
     fun toApplicationApprovedTemplatePersonalisationMap(dto: ApplicationApprovedPersonalisationDto): Map<String, String> {
@@ -79,6 +90,7 @@ class TemplatePersonalisationDtoMapper {
                 eroContactDetails.mapEroContactFields(this)
                 personalisation.putAll(this)
             }
+            personalisation["sourceType"] = sourceType
         }
         return personalisation
     }
@@ -95,6 +107,7 @@ class TemplatePersonalisationDtoMapper {
                 eroContactDetails.mapEroContactFields(this)
                 personalisation.putAll(this)
             }
+            personalisation["sourceType"] = sourceType
         }
         return personalisation
     }
@@ -112,6 +125,7 @@ class TemplatePersonalisationDtoMapper {
                 eroContactDetails.mapEroContactFields(this)
                 personalisation.putAll(this)
             }
+            personalisation["sourceType"] = sourceType
         }
         return personalisation
     }
@@ -127,6 +141,7 @@ class TemplatePersonalisationDtoMapper {
                 eroContactDetails.mapEroContactFields(this)
                 personalisation.putAll(this)
             }
+            personalisation["sourceType"] = sourceType
         }
         return personalisation
     }
@@ -142,6 +157,7 @@ class TemplatePersonalisationDtoMapper {
                 eroContactDetails.mapEroContactFields(this)
                 personalisation.putAll(this)
             }
+            personalisation["sourceType"] = sourceType
         }
         return personalisation
     }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyApplicationReceivedMessageListener.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyApplicationReceivedMessageListener.kt
@@ -32,7 +32,8 @@ class SendNotifyApplicationReceivedMessageListener(
         }
         with(payload) {
             val sendNotificationRequestDto = sendNotifyMessageMapper.fromReceivedMessageToSendNotificationRequestDto(this)
-            val personalisationDto = templatePersonalisationMessageMapper.toReceivedPersonalisationDto(personalisation)
+            val personalisationDto = templatePersonalisationMessageMapper
+                .toReceivedPersonalisationDto(personalisation, sendNotificationRequestDto.language, sourceType)
             val personalisationMap = templatePersonalisationDtoMapper.toApplicationReceivedTemplatePersonalisationMap(personalisationDto)
             sendNotificationService.sendNotification(sendNotificationRequestDto, personalisationMap)
         }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyApplicationRejectedMessageListener.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyApplicationRejectedMessageListener.kt
@@ -31,8 +31,7 @@ class SendNotifyApplicationRejectedMessageListener(
         }
         with(payload) {
             val sendNotificationRequestDto = sendNotifyMessageMapper.fromRejectedMessageToSendNotificationRequestDto(this)
-            val personalisationDto = templatePersonalisationMessageMapper
-                .toRejectedPersonalisationDto(personalisation, sendNotificationRequestDto.language, sourceType)
+            val personalisationDto = templatePersonalisationMessageMapper.toRejectedPersonalisationDto(personalisation, sendNotificationRequestDto.language)
             val personalisationMap = templatePersonalisationDtoMapper.toApplicationRejectedTemplatePersonalisationMap(personalisationDto)
             sendNotificationService.sendNotification(sendNotificationRequestDto, personalisationMap)
         }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyApplicationRejectedMessageListener.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyApplicationRejectedMessageListener.kt
@@ -31,7 +31,8 @@ class SendNotifyApplicationRejectedMessageListener(
         }
         with(payload) {
             val sendNotificationRequestDto = sendNotifyMessageMapper.fromRejectedMessageToSendNotificationRequestDto(this)
-            val personalisationDto = templatePersonalisationMessageMapper.toRejectedPersonalisationDto(personalisation, sendNotificationRequestDto.language)
+            val personalisationDto = templatePersonalisationMessageMapper
+                .toRejectedPersonalisationDto(personalisation, sendNotificationRequestDto.language, sourceType)
             val personalisationMap = templatePersonalisationDtoMapper.toApplicationRejectedTemplatePersonalisationMap(personalisationDto)
             sendNotificationService.sendNotification(sendNotificationRequestDto, personalisationMap)
         }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyNinoNotMatchedMessageListener.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyNinoNotMatchedMessageListener.kt
@@ -33,7 +33,8 @@ class SendNotifyNinoNotMatchedMessageListener(
         }
         with(payload) {
             val sendNotificationRequestDto = sendNotifyMessageMapper.fromNinoNotMatchedMessageToSendNotificationRequestDto(this)
-            val personalisationDto = templatePersonalisationMessageMapper.toNinoNotMatchedPersonalisationDto(personalisation, sendNotificationRequestDto.language)
+            val personalisationDto = templatePersonalisationMessageMapper
+                .toNinoNotMatchedPersonalisationDto(personalisation, sendNotificationRequestDto.language, sourceType)
             val personalisationMap = templatePersonalisationDtoMapper.toNinoNotMatchedTemplatePersonalisationMap(personalisationDto)
             sendNotificationService.sendNotification(sendNotificationRequestDto, personalisationMap)
         }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyRejectedDocumentMessageListener.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyRejectedDocumentMessageListener.kt
@@ -32,7 +32,8 @@ class SendNotifyRejectedDocumentMessageListener(
         }
         with(payload) {
             val sendNotificationRequestDto = sendNotifyMessageMapper.fromRejectedDocumentMessageToSendNotificationRequestDto(this)
-            val personalisationDto = templatePersonalisationMessageMapper.toRejectedDocumentPersonalisationDto(personalisation, sendNotificationRequestDto.language)
+            val personalisationDto = templatePersonalisationMessageMapper
+                .toRejectedDocumentPersonalisationDto(personalisation, sendNotificationRequestDto.language, sourceType)
             val personalisationMap = templatePersonalisationDtoMapper.toRejectedDocumentTemplatePersonalisationMap(personalisationDto)
             sendNotificationService.sendNotification(sendNotificationRequestDto, personalisationMap)
         }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyRejectedSignatureMessageListener.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyRejectedSignatureMessageListener.kt
@@ -33,8 +33,8 @@ class SendNotifyRejectedSignatureMessageListener(
                     "language: $language"
             }
             val sendNotificationRequestDto = sendNotifyMessageMapper.fromRejectedSignatureToSendNotificationRequestDto(this)
-            val personalisationDto =
-                templatePersonalisationMessageMapper.toRejectedSignaturePersonalisationDto(personalisation, sendNotificationRequestDto.language)
+            val personalisationDto = templatePersonalisationMessageMapper
+                .toRejectedSignaturePersonalisationDto(personalisation, sendNotificationRequestDto.language, sourceType)
             val personalisationMap =
                 templatePersonalisationDtoMapper.toRejectedSignatureTemplatePersonalisationMap(personalisationDto)
             sendNotificationService.sendNotification(

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyRequestedSignatureMessageListener.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyRequestedSignatureMessageListener.kt
@@ -33,8 +33,8 @@ class SendNotifyRequestedSignatureMessageListener(
                     "language: $language"
             }
             val sendNotificationRequestDto = sendNotifyMessageMapper.fromRequestedSignatureToSendNotificationRequestDto(this)
-            val personalisationDto =
-                templatePersonalisationMessageMapper.toRequestedSignaturePersonalisationDto(personalisation)
+            val personalisationDto = templatePersonalisationMessageMapper
+                .toRequestedSignaturePersonalisationDto(personalisation, sendNotificationRequestDto.language, sourceType)
             val personalisationMap =
                 templatePersonalisationDtoMapper.toRequestedSignatureTemplatePersonalisationMap(personalisationDto)
             sendNotificationService.sendNotification(

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/TemplatePersonalisationMessageMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/TemplatePersonalisationMessageMapper.kt
@@ -107,17 +107,12 @@ abstract class TemplatePersonalisationMessageMapper {
     abstract fun toApprovedPersonalisationDto(personalisationMessage: BasePersonalisation): ApplicationApprovedPersonalisationDto
 
     @Mapping(
-        target = "sourceType",
-        expression = "java( mapSourceType( languageDto, sourceType ) )",
-    )
-    @Mapping(
         target = "rejectionReasonList",
         expression = "java( mapApplicationRejectionReasons( languageDto, personalisationMessage ) )"
     )
     abstract fun toRejectedPersonalisationDto(
         personalisationMessage: ApplicationRejectedPersonalisation,
         languageDto: LanguageDto,
-        sourceType: SourceType,
     ): ApplicationRejectedPersonalisationDto
 
     protected fun mapApplicationRejectionReasons(

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/TemplatePersonalisationMessageMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/TemplatePersonalisationMessageMapper.kt
@@ -20,6 +20,7 @@ import uk.gov.dluhc.notificationsapi.mapper.IdentityDocumentResubmissionDocument
 import uk.gov.dluhc.notificationsapi.mapper.PhotoRejectionReasonMapper
 import uk.gov.dluhc.notificationsapi.mapper.RejectedDocumentsMapper
 import uk.gov.dluhc.notificationsapi.mapper.SignatureRejectionReasonMapper
+import uk.gov.dluhc.notificationsapi.mapper.SourceTypeMapper
 import uk.gov.dluhc.notificationsapi.messaging.models.ApplicationRejectedPersonalisation
 import uk.gov.dluhc.notificationsapi.messaging.models.BasePersonalisation
 import uk.gov.dluhc.notificationsapi.messaging.models.IdDocumentPersonalisation
@@ -29,6 +30,7 @@ import uk.gov.dluhc.notificationsapi.messaging.models.PhotoPersonalisation
 import uk.gov.dluhc.notificationsapi.messaging.models.RejectedDocumentPersonalisation
 import uk.gov.dluhc.notificationsapi.messaging.models.RejectedSignaturePersonalisation
 import uk.gov.dluhc.notificationsapi.messaging.models.RequestedSignaturePersonalisation
+import uk.gov.dluhc.notificationsapi.messaging.models.SourceType
 
 @Mapper
 abstract class TemplatePersonalisationMessageMapper {
@@ -48,6 +50,9 @@ abstract class TemplatePersonalisationMessageMapper {
     @Autowired
     protected lateinit var rejectedDocumentsMapper: RejectedDocumentsMapper
 
+    @Autowired
+    protected lateinit var sourceTypeMapper: SourceTypeMapper
+
     @Mapping(
         target = "photoRejectionReasons",
         expression = "java( mapPhotoRejectionReasons( languageDto, personalisationMessage ) )"
@@ -58,15 +63,28 @@ abstract class TemplatePersonalisationMessageMapper {
     ): PhotoPersonalisationDto
 
     @Mapping(
+        target = "sourceType",
+        expression = "java( mapSourceType( languageDto, sourceType ) )",
+    )
+    @Mapping(
         target = "rejectionReasons",
         expression = "java( mapSignatureRejectionReasons( languageDto, personalisationMessage ) )"
     )
     abstract fun toRejectedSignaturePersonalisationDto(
         personalisationMessage: RejectedSignaturePersonalisation,
-        languageDto: LanguageDto
+        languageDto: LanguageDto,
+        sourceType: SourceType,
     ): RejectedSignaturePersonalisationDto
 
-    abstract fun toRequestedSignaturePersonalisationDto(personalisationMessage: RequestedSignaturePersonalisation): RequestedSignaturePersonalisationDto
+    @Mapping(
+        target = "sourceType",
+        expression = "java( mapSourceType( languageDto, sourceType ) )",
+    )
+    abstract fun toRequestedSignaturePersonalisationDto(
+        personalisationMessage: RequestedSignaturePersonalisation,
+        languageDto: LanguageDto,
+        sourceType: SourceType,
+    ): RequestedSignaturePersonalisationDto
 
     @Mapping(
         target = "documentRejectionText",
@@ -76,17 +94,30 @@ abstract class TemplatePersonalisationMessageMapper {
 
     abstract fun toIdDocumentRequiredPersonalisationDto(personalisationMessage: IdDocumentRequiredPersonalisation): IdDocumentRequiredPersonalisationDto
 
-    abstract fun toReceivedPersonalisationDto(personalisationMessage: BasePersonalisation): ApplicationReceivedPersonalisationDto
+    @Mapping(
+        target = "sourceType",
+        expression = "java( mapSourceType( languageDto, sourceType ) )",
+    )
+    abstract fun toReceivedPersonalisationDto(
+        personalisationMessage: BasePersonalisation,
+        languageDto: LanguageDto,
+        sourceType: SourceType,
+    ): ApplicationReceivedPersonalisationDto
 
     abstract fun toApprovedPersonalisationDto(personalisationMessage: BasePersonalisation): ApplicationApprovedPersonalisationDto
 
+    @Mapping(
+        target = "sourceType",
+        expression = "java( mapSourceType( languageDto, sourceType ) )",
+    )
     @Mapping(
         target = "rejectionReasonList",
         expression = "java( mapApplicationRejectionReasons( languageDto, personalisationMessage ) )"
     )
     abstract fun toRejectedPersonalisationDto(
         personalisationMessage: ApplicationRejectedPersonalisation,
-        languageDto: LanguageDto
+        languageDto: LanguageDto,
+        sourceType: SourceType,
     ): ApplicationRejectedPersonalisationDto
 
     protected fun mapApplicationRejectionReasons(
@@ -102,20 +133,35 @@ abstract class TemplatePersonalisationMessageMapper {
     }
 
     @Mapping(
+        target = "sourceType",
+        expression = "java( mapSourceType( languageDto, sourceType ) )",
+    )
+    @Mapping(
         target = "documents",
         expression = "java( rejectedDocumentsMapper.mapRejectionDocumentsFromMessaging(languageDto, personalisation.getDocuments()) )"
     )
     @Mapping(target = "rejectedDocumentFreeText", source = "personalisation.rejectedDocumentMessage")
     abstract fun toRejectedDocumentPersonalisationDto(
         personalisation: RejectedDocumentPersonalisation,
-        languageDto: LanguageDto
+        languageDto: LanguageDto,
+        sourceType: SourceType,
     ): RejectedDocumentPersonalisationDto
 
+    @Mapping(
+        target = "sourceType",
+        expression = "java( mapSourceType( languageDto, sourceType ) )",
+    )
     @Mapping(target = "additionalNotes", source = "personalisation.additionalNotes")
     abstract fun toNinoNotMatchedPersonalisationDto(
         personalisation: NinoNotMatchedPersonalisation,
-        languageDto: LanguageDto
+        languageDto: LanguageDto,
+        sourceType: SourceType,
     ): NinoNotMatchedPersonalisationDto
+
+    protected fun mapSourceType(
+        languageDto: LanguageDto,
+        sourceType: SourceType,
+    ): String = sourceTypeMapper.toSourceTypeString(sourceType, languageDto)
 
     protected fun mapPhotoRejectionReasons(
         languageDto: LanguageDto,

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,3 +1,8 @@
+templates.vote-type.overseas=
+templates.vote-type.postal= postal
+templates.vote-type.proxy= proxy
+templates.vote-type.voter-card=
+
 templates.application-rejection.rejection-reasons.incomplete-application= Your application was incomplete
 templates.application-rejection.rejection-reasons.inaccurate-information= Your application contained inaccurate information
 templates.application-rejection.rejection-reasons.photo-is-not-acceptable= Your photo did not meet the criteria

--- a/src/main/resources/messages_cy.properties
+++ b/src/main/resources/messages_cy.properties
@@ -1,3 +1,8 @@
+templates.vote-type.overseas=
+templates.vote-type.postal= drwy'r post
+templates.vote-type.proxy= drwy ddirprwy
+templates.vote-type.voter-card=
+
 templates.application-rejection.rejection-reasons.incomplete-application= Mae'r cais yn anghyflawn
 templates.application-rejection.rejection-reasons.inaccurate-information= Mae'r cais yn cynnwys gwybodaeth anghywir
 templates.application-rejection.rejection-reasons.photo-is-not-acceptable= Nid yw'r ffotograff yn bodloni'r meini prawf

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -1,3 +1,8 @@
+templates.vote-type.overseas=
+templates.vote-type.postal= postal
+templates.vote-type.proxy= proxy
+templates.vote-type.voter-card=
+
 templates.application-rejection.rejection-reasons.incomplete-application= Your application was incomplete
 templates.application-rejection.rejection-reasons.inaccurate-information= Your application contained inaccurate information
 templates.application-rejection.rejection-reasons.photo-is-not-acceptable= Your photo did not meet the criteria

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/GenerateApplicationReceivedTemplatePreviewDtoMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/GenerateApplicationReceivedTemplatePreviewDtoMapperTest.kt
@@ -41,6 +41,7 @@ class GenerateApplicationReceivedTemplatePreviewDtoMapperTest {
 
         given(languageMapper.fromApiToDto(any())).willReturn(LanguageDto.ENGLISH)
         given(sourceTypeMapper.fromApiToDto(any())).willReturn(SourceTypeDto.VOTER_CARD)
+        given(sourceTypeMapper.toSourceTypeString(SourceTypeModel.VOTER_MINUS_CARD, LanguageDto.ENGLISH)).willReturn("Mapped source type")
 
         val expected = buildGenerateApplicationReceivedTemplatePreviewDto(
             sourceType = SourceTypeDto.VOTER_CARD,
@@ -66,7 +67,8 @@ class GenerateApplicationReceivedTemplatePreviewDtoMapperTest {
                                 )
                             }
                         )
-                    }
+                    },
+                    sourceType = "Mapped source type",
                 )
             }
         )
@@ -78,5 +80,6 @@ class GenerateApplicationReceivedTemplatePreviewDtoMapperTest {
         assertThat(actual).usingRecursiveComparison().isEqualTo(expected)
         verify(languageMapper).fromApiToDto(Language.EN)
         verify(sourceTypeMapper).fromApiToDto(SourceTypeModel.VOTER_MINUS_CARD)
+        verify(sourceTypeMapper).toSourceTypeString(SourceTypeModel.VOTER_MINUS_CARD, LanguageDto.ENGLISH)
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/RejectedDocumentTemplatePreviewDtoMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/RejectedDocumentTemplatePreviewDtoMapperTest.kt
@@ -68,6 +68,7 @@ class RejectedDocumentTemplatePreviewDtoMapperTest {
         )
         given(languageMapper.fromApiToDto(language)).willReturn(ENGLISH)
         given(sourceTypeMapper.fromApiToDto(sourceTypeModel)).willReturn(sourceTypeDto)
+        given(sourceTypeMapper.toSourceTypeString(sourceTypeModel, ENGLISH)).willReturn("Mapped source type")
         given(rejectedDocumentsMapper.mapRejectionDocumentsFromApi(ENGLISH, documents)).willReturn(listOf("Doc1", "Doc2"))
 
         // When
@@ -101,7 +102,8 @@ class RejectedDocumentTemplatePreviewDtoMapperTest {
                                 )
                             }
                         )
-                    }
+                    },
+                    sourceType = "Mapped source type",
                 )
             }
         )
@@ -128,6 +130,7 @@ class RejectedDocumentTemplatePreviewDtoMapperTest {
         )
         given(languageMapper.fromApiToDto(language)).willReturn(ENGLISH)
         given(sourceTypeMapper.fromApiToDto(sourceTypeModel)).willReturn(sourceTypeDto)
+        given(sourceTypeMapper.toSourceTypeString(sourceTypeModel, ENGLISH)).willReturn("Mapped source type")
         given(rejectedDocumentsMapper.mapRejectionDocumentsFromApi(ENGLISH, documents)).willReturn(listOf("Doc1"))
 
         // When
@@ -161,7 +164,8 @@ class RejectedDocumentTemplatePreviewDtoMapperTest {
                                 )
                             }
                         )
-                    }
+                    },
+                    sourceType = "Mapped source type",
                 )
             }
         )

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/RejectedSignatureTemplatePreviewDtoMapper_NotificationTypeTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/RejectedSignatureTemplatePreviewDtoMapper_NotificationTypeTest.kt
@@ -91,6 +91,7 @@ class RejectedSignatureTemplatePreviewDtoMapper_NotificationTypeTest {
         given(languageMapper.fromApiToDto(any())).willReturn(LanguageDto.ENGLISH)
         given(notificationChannelMapper.fromApiToDto(any())).willReturn(aNotificationChannel())
         given(sourceTypeMapper.fromApiToDto(any())).willReturn(aSourceType())
+        given(sourceTypeMapper.toSourceTypeString(sourceType, LanguageDto.ENGLISH)).willReturn("Mapped source type")
 
         // When
         val actual = mapper.toRejectedSignatureTemplatePreviewDto(request)
@@ -127,6 +128,7 @@ class RejectedSignatureTemplatePreviewDtoMapper_NotificationTypeTest {
         given(languageMapper.fromApiToDto(any())).willReturn(LanguageDto.ENGLISH)
         given(notificationChannelMapper.fromApiToDto(any())).willReturn(aNotificationChannel())
         given(sourceTypeMapper.fromApiToDto(any())).willReturn(aSourceType())
+        given(sourceTypeMapper.toSourceTypeString(sourceType, LanguageDto.ENGLISH)).willReturn("Mapped source type")
 
         // When
         val actual = mapper.toRejectedSignatureTemplatePreviewDto(request)

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/SourceTypeMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/SourceTypeMapperTest.kt
@@ -3,13 +3,21 @@ package uk.gov.dluhc.notificationsapi.mapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
+import org.springframework.context.support.ResourceBundleMessageSource
+import uk.gov.dluhc.notificationsapi.dto.LanguageDto
 import uk.gov.dluhc.notificationsapi.database.entity.SourceType as SourceTypeEntityEnum
 import uk.gov.dluhc.notificationsapi.dto.SourceType as SourceTypeDto
 import uk.gov.dluhc.notificationsapi.messaging.models.SourceType as SourceTypeMessageEnum
 import uk.gov.dluhc.notificationsapi.models.SourceType as SourceTypeModel
 
 class SourceTypeMapperTest {
-    private val mapper = SourceTypeMapperImpl()
+
+    private val messageSource = ResourceBundleMessageSource().apply {
+        setBasenames("messages")
+        setDefaultEncoding("UTF-8")
+        setFallbackToSystemLocale(true)
+    }
+    private val mapper = SourceTypeMapper(messageSource)
 
     @ParameterizedTest
     @CsvSource(
@@ -94,6 +102,94 @@ class SourceTypeMapperTest {
 
         // When
         val actual = mapper.fromApiToDto(apiSourceTypeEnum)
+
+        // Then
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        value = [
+            "OVERSEAS,''",
+            "POSTAL,postal",
+            "PROXY,proxy",
+            "VOTER_MINUS_CARD,''",
+        ],
+    )
+    fun `should map message sourceType to human readable messages in English`(
+        sourceType: SourceTypeMessageEnum,
+        expected: String,
+    ) {
+        // Given
+
+        // When
+        val actual = mapper.toSourceTypeString(sourceType, LanguageDto.ENGLISH)
+
+        // Then
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        value = [
+            "OVERSEAS,''",
+            "POSTAL,postal",
+            "PROXY,proxy",
+            "VOTER_MINUS_CARD,''",
+        ],
+    )
+    fun `should map API sourceType to human readable messages in English`(
+        sourceType: SourceTypeModel,
+        expected: String,
+    ) {
+        // Given
+
+        // When
+        val actual = mapper.toSourceTypeString(sourceType, LanguageDto.ENGLISH)
+
+        // Then
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        value = [
+            "OVERSEAS,''",
+            "POSTAL,drwy'r post",
+            "PROXY,drwy ddirprwy",
+            "VOTER_MINUS_CARD,''",
+        ],
+    )
+    fun `should map message sourceType to human readable messages in Welsh`(
+        sourceType: SourceTypeMessageEnum,
+        expected: String,
+    ) {
+        // Given
+
+        // When
+        val actual = mapper.toSourceTypeString(sourceType, LanguageDto.WELSH)
+
+        // Then
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        value = [
+            "OVERSEAS,''",
+            "POSTAL,drwy'r post",
+            "PROXY,drwy ddirprwy",
+            "VOTER_MINUS_CARD,''",
+        ],
+    )
+    fun `should map API sourceType to human readable messages in Welsh`(
+        sourceType: SourceTypeModel,
+        expected: String,
+    ) {
+        // Given
+
+        // When
+        val actual = mapper.toSourceTypeString(sourceType, LanguageDto.WELSH)
 
         // Then
         assertThat(actual).isEqualTo(expected)

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/TemplatePersonalisationDtoMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/TemplatePersonalisationDtoMapperTest.kt
@@ -177,11 +177,11 @@ class TemplatePersonalisationDtoMapperTest {
 
             // Then
             assertThat(actual).usingRecursiveComparison().isEqualTo(expected)
-            assertThat(actual["eroAddressLine1"]).isBlank
+            assertThat(actual["eroAddressLine1"] as String).isBlank
             assertThat(actual["eroAddressLine2"]).isEqualTo(personalisationDto.eroContactDetails.address.street)
-            assertThat(actual["eroAddressLine3"]).isBlank
-            assertThat(actual["eroAddressLine4"]).isBlank
-            assertThat(actual["eroAddressLine5"]).isBlank
+            assertThat(actual["eroAddressLine3"] as String).isBlank
+            assertThat(actual["eroAddressLine4"] as String).isBlank
+            assertThat(actual["eroAddressLine5"] as String).isBlank
             assertThat(actual["eroPostcode"]).isEqualTo(personalisationDto.eroContactDetails.address.postcode)
         }
     }

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyApplicationReceivedMessageListenerTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyApplicationReceivedMessageListenerTest.kt
@@ -6,7 +6,6 @@ import org.mockito.BDDMockito.given
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 import uk.gov.dluhc.notificationsapi.mapper.TemplatePersonalisationDtoMapper
 import uk.gov.dluhc.notificationsapi.messaging.mapper.SendNotifyMessageMapper
@@ -43,16 +42,16 @@ internal class SendNotifyApplicationReceivedMessageListenerTest {
         val personalisationMap = aNotificationPersonalisationMap()
         val personalisationDto = buildApplicationReceivedPersonalisationDto()
 
-        given(sendNotifyMessageMapper.fromReceivedMessageToSendNotificationRequestDto(any())).willReturn(requestDto)
-        given(templatePersonalisationMessageMapper.toReceivedPersonalisationDto(any())).willReturn(personalisationDto)
-        given(templatePersonalisationDtoMapper.toApplicationReceivedTemplatePersonalisationMap(any())).willReturn(personalisationMap)
+        given(sendNotifyMessageMapper.fromReceivedMessageToSendNotificationRequestDto(sqsMessage)).willReturn(requestDto)
+        given(templatePersonalisationMessageMapper.toReceivedPersonalisationDto(sqsMessage.personalisation, requestDto.language, sqsMessage.sourceType)).willReturn(personalisationDto)
+        given(templatePersonalisationDtoMapper.toApplicationReceivedTemplatePersonalisationMap(personalisationDto)).willReturn(personalisationMap)
 
         // When
         listener.handleMessage(sqsMessage)
 
         // Then
         verify(sendNotifyMessageMapper).fromReceivedMessageToSendNotificationRequestDto(sqsMessage)
-        verify(templatePersonalisationMessageMapper).toReceivedPersonalisationDto(sqsMessage.personalisation)
+        verify(templatePersonalisationMessageMapper).toReceivedPersonalisationDto(sqsMessage.personalisation, requestDto.language, sqsMessage.sourceType)
         verify(templatePersonalisationDtoMapper).toApplicationReceivedTemplatePersonalisationMap(personalisationDto)
         verify(sendNotificationService).sendNotification(requestDto, personalisationMap)
     }

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyNinoNotMatchedMessageListenerTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyNinoNotMatchedMessageListenerTest.kt
@@ -43,7 +43,7 @@ internal class SendNotifyNinoNotMatchedMessageListenerTest {
         val personalisationDto = buildNinoNotMatchedPersonalisationDto()
 
         given(sendNotifyMessageMapper.fromNinoNotMatchedMessageToSendNotificationRequestDto(sqsMessage)).willReturn(requestDto)
-        given(templatePersonalisationMessageMapper.toNinoNotMatchedPersonalisationDto(sqsMessage.personalisation, requestDto.language)).willReturn(personalisationDto)
+        given(templatePersonalisationMessageMapper.toNinoNotMatchedPersonalisationDto(sqsMessage.personalisation, requestDto.language, sqsMessage.sourceType)).willReturn(personalisationDto)
         given(templatePersonalisationDtoMapper.toNinoNotMatchedTemplatePersonalisationMap(personalisationDto)).willReturn(personalisationMap)
 
         // When

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyRejectedDocumentMessageListenerTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyRejectedDocumentMessageListenerTest.kt
@@ -43,7 +43,7 @@ internal class SendNotifyRejectedDocumentMessageListenerTest {
         val personalisationDto = buildRejectedDocumentPersonalisationDto()
 
         given(sendNotifyMessageMapper.fromRejectedDocumentMessageToSendNotificationRequestDto(sqsMessage)).willReturn(requestDto)
-        given(templatePersonalisationMessageMapper.toRejectedDocumentPersonalisationDto(sqsMessage.personalisation, requestDto.language)).willReturn(personalisationDto)
+        given(templatePersonalisationMessageMapper.toRejectedDocumentPersonalisationDto(sqsMessage.personalisation, requestDto.language, sqsMessage.sourceType)).willReturn(personalisationDto)
         given(templatePersonalisationDtoMapper.toRejectedDocumentTemplatePersonalisationMap(personalisationDto)).willReturn(personalisationMap)
 
         // When

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyRejectedSignatureMessageListenerTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyRejectedSignatureMessageListenerTest.kt
@@ -45,7 +45,8 @@ class SendNotifyRejectedSignatureMessageListenerTest {
         BDDMockito.given(
             templatePersonalisationMessageMapper.toRejectedSignaturePersonalisationDto(
                 sqsMessage.personalisation,
-                requestDto.language
+                requestDto.language,
+                sqsMessage.sourceType,
             )
         ).willReturn(personalisationDto)
         BDDMockito.given(

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyRequestedSignatureMessageListenerTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyRequestedSignatureMessageListenerTest.kt
@@ -44,7 +44,7 @@ class SendNotifyRequestedSignatureMessageListenerTest {
 
         given(sendNotifyMessageMapper.fromRequestedSignatureToSendNotificationRequestDto(sqsMessage))
             .willReturn(requestDto)
-        given(templatePersonalisationMessageMapper.toRequestedSignaturePersonalisationDto(sqsMessage.personalisation))
+        given(templatePersonalisationMessageMapper.toRequestedSignaturePersonalisationDto(sqsMessage.personalisation, requestDto.language, sqsMessage.sourceType))
             .willReturn(personalisationDto)
         given(templatePersonalisationDtoMapper.toRequestedSignatureTemplatePersonalisationMap(personalisationDto))
             .willReturn(personalisationMap)

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GenerateNinoNotMatchedTemplatePreviewIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GenerateNinoNotMatchedTemplatePreviewIntegrationTest.kt
@@ -197,20 +197,22 @@ internal class GenerateNinoNotMatchedTemplatePreviewIntegrationTest : Integratio
     @ParameterizedTest
     @CsvSource(
         value = [
-            "POSTAL, EMAIL,$EMAIL_ENGLISH_TEMPLATE_ID,EN",
-            "POSTAL, LETTER,$LETTER_ENGLISH_TEMPLATE_ID,EN",
-            "POSTAL, EMAIL,$EMAIL_WELSH_TEMPLATE_ID,CY",
-            "POSTAL, LETTER,$LETTER_WELSH_TEMPLATE_ID,CY",
-            "PROXY, EMAIL,$EMAIL_ENGLISH_TEMPLATE_ID,EN",
-            "PROXY, LETTER,$LETTER_ENGLISH_TEMPLATE_ID,EN",
-            "PROXY, EMAIL,$EMAIL_WELSH_TEMPLATE_ID,CY",
-            "PROXY, LETTER,$LETTER_WELSH_TEMPLATE_ID,CY"
+            "POSTAL, EMAIL,$EMAIL_ENGLISH_TEMPLATE_ID,EN,postal",
+            "POSTAL, LETTER,$LETTER_ENGLISH_TEMPLATE_ID,EN,postal",
+            "POSTAL, EMAIL,$EMAIL_WELSH_TEMPLATE_ID,CY,drwy'r post",
+            "POSTAL, LETTER,$LETTER_WELSH_TEMPLATE_ID,CY,drwy'r post",
+            "PROXY, EMAIL,$EMAIL_ENGLISH_TEMPLATE_ID,EN,proxy",
+            "PROXY, LETTER,$LETTER_ENGLISH_TEMPLATE_ID,EN,proxy",
+            "PROXY, EMAIL,$EMAIL_WELSH_TEMPLATE_ID,CY,drwy ddirprwy",
+            "PROXY, LETTER,$LETTER_WELSH_TEMPLATE_ID,CY,drwy ddirprwy"
         ]
     )
     fun `should return template preview given valid request`(
         sourceType: SourceType,
         notificationChannel: NotificationChannel,
-        templateId: String
+        templateId: String,
+        language: Language,
+        expectedPersonalisationSourceType: String,
     ) {
         // Given
         val notifyClientResponse = NotifyGenerateTemplatePreviewSuccessResponse(id = templateId)
@@ -218,6 +220,7 @@ internal class GenerateNinoNotMatchedTemplatePreviewIntegrationTest : Integratio
         val requestBody = buildGenerateNinoNotMatchedTemplatePreviewRequest(
             sourceType = sourceType,
             channel = notificationChannel,
+            language = language,
             personalisation = buildNinoNotMatchedPersonalisation(
                 additionalNotes = "Invalid"
             )
@@ -251,7 +254,8 @@ internal class GenerateNinoNotMatchedTemplatePreviewIntegrationTest : Integratio
                 "eroAddressLine3" to eroContactDetails.address.town!!,
                 "eroAddressLine4" to eroContactDetails.address.area!!,
                 "eroAddressLine5" to eroContactDetails.address.locality!!,
-                "eroPostcode" to eroContactDetails.address.postcode
+                "eroPostcode" to eroContactDetails.address.postcode,
+                "sourceType" to expectedPersonalisationSourceType,
             )
         }
         wireMockService.verifyNotifyGenerateTemplatePreview(templateId, expectedPersonalisationDataMap)
@@ -266,7 +270,7 @@ internal class GenerateNinoNotMatchedTemplatePreviewIntegrationTest : Integratio
     )
     fun `should return template preview given valid request when optional values are not populated`(
         notificationChannel: NotificationChannel,
-        templateId: String
+        templateId: String,
     ) {
         // Given
         val notifyClientResponse = NotifyGenerateTemplatePreviewSuccessResponse(id = templateId)
@@ -293,7 +297,8 @@ internal class GenerateNinoNotMatchedTemplatePreviewIntegrationTest : Integratio
                 "eroAddressLine3" to "",
                 "eroAddressLine4" to "",
                 "eroAddressLine5" to "",
-                "eroPostcode" to eroContactDetails.address.postcode
+                "eroPostcode" to eroContactDetails.address.postcode,
+                "sourceType" to "postal",
             )
         }
 
@@ -324,6 +329,4 @@ internal class GenerateNinoNotMatchedTemplatePreviewIntegrationTest : Integratio
             GenerateNinoNotMatchedTemplatePreviewRequest::class.java
         ) as WebTestClient.RequestBodySpec
     }
-
-    private fun Language?.toMessage(): String = if (this == Language.CY) "Welsh" else "English"
 }

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GenerateRejectedDocumentTemplatePreviewIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GenerateRejectedDocumentTemplatePreviewIntegrationTest.kt
@@ -221,7 +221,11 @@ internal class GenerateRejectedDocumentTemplatePreviewIntegrationTest : Integrat
             mutableMapOf(
                 "applicationReference" to applicationReference,
                 "firstName" to firstName,
-                "rejectedDocuments" to listOf("Utility bill - The document is too old - Some notes here"),
+                "rejectedDocuments" to listOf(
+                    "Utility bill\n" +
+                        "  * The document is too old\n" +
+                        "  * Some notes here"
+                ),
                 "rejectionMessage" to rejectedDocumentFreeText!!,
                 "LAName" to eroContactDetails.localAuthorityName,
                 "eroWebsite" to eroContactDetails.website,
@@ -260,7 +264,11 @@ internal class GenerateRejectedDocumentTemplatePreviewIntegrationTest : Integrat
             mapOf(
                 "applicationReference" to applicationReference,
                 "firstName" to firstName,
-                "rejectedDocuments" to listOf("Utility bill - The document is too old - Notes for letter"),
+                "rejectedDocuments" to listOf(
+                    "Utility bill\n" +
+                        "  * The document is too old\n" +
+                        "  * Notes for letter"
+                ),
                 "rejectionMessage" to rejectedDocumentFreeText!!,
                 "LAName" to eroContactDetails.localAuthorityName,
                 "eroWebsite" to eroContactDetails.website,

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GenerateRejectedDocumentTemplatePreviewIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GenerateRejectedDocumentTemplatePreviewIntegrationTest.kt
@@ -232,7 +232,8 @@ internal class GenerateRejectedDocumentTemplatePreviewIntegrationTest : Integrat
                 "eroAddressLine3" to eroContactDetails.address.town!!,
                 "eroAddressLine4" to eroContactDetails.address.area!!,
                 "eroAddressLine5" to eroContactDetails.address.locality!!,
-                "eroPostcode" to eroContactDetails.address.postcode
+                "eroPostcode" to eroContactDetails.address.postcode,
+                "sourceType" to sourceType.value,
             )
         }
         wireMockService.verifyNotifyGenerateTemplatePreview(EMAIL_DOCUMENT_TEMPLATE_ID, expectedPersonalisationDataMap)
@@ -270,7 +271,8 @@ internal class GenerateRejectedDocumentTemplatePreviewIntegrationTest : Integrat
                 "eroAddressLine3" to eroContactDetails.address.town!!,
                 "eroAddressLine4" to eroContactDetails.address.area!!,
                 "eroAddressLine5" to eroContactDetails.address.locality!!,
-                "eroPostcode" to eroContactDetails.address.postcode
+                "eroPostcode" to eroContactDetails.address.postcode,
+                "sourceType" to sourceType.value,
             )
         }
         val expected = with(notifyClientResponse) { GenerateTemplatePreviewResponse(body, subject, html) }
@@ -325,7 +327,8 @@ internal class GenerateRejectedDocumentTemplatePreviewIntegrationTest : Integrat
                 "eroAddressLine3" to "",
                 "eroAddressLine4" to "",
                 "eroAddressLine5" to "",
-                "eroPostcode" to eroContactDetails.address.postcode
+                "eroPostcode" to eroContactDetails.address.postcode,
+                "sourceType" to sourceType.value,
             )
         }
 

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GenerateRejectedSignatureTemplatePreviewIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GenerateRejectedSignatureTemplatePreviewIntegrationTest.kt
@@ -209,22 +209,22 @@ internal class GenerateRejectedSignatureTemplatePreviewIntegrationTest : Integra
     @ParameterizedTest
     @CsvSource(
         value = [
-            "POSTAL, EMAIL,$POSTAL_EMAIL_SIGNATURE_ENGLISH_TEMPLATE_ID,EN,false",
-            "POSTAL, LETTER,$POSTAL_LETTER_SIGNATURE_ENGLISH_TEMPLATE_ID,EN,false",
-            "POSTAL, EMAIL,$POSTAL_EMAIL_SIGNATURE_WELSH_TEMPLATE_ID,CY,false",
-            "POSTAL, LETTER,$POSTAL_LETTER_SIGNATURE_WELSH_TEMPLATE_ID,CY,false",
-            "PROXY, EMAIL,$PROXY_EMAIL_SIGNATURE_ENGLISH_TEMPLATE_ID,EN,false",
-            "PROXY, LETTER,$PROXY_LETTER_SIGNATURE_ENGLISH_TEMPLATE_ID,EN,false",
-            "PROXY, EMAIL,$PROXY_EMAIL_SIGNATURE_WELSH_TEMPLATE_ID,CY,false",
-            "PROXY, LETTER,$PROXY_LETTER_SIGNATURE_WELSH_TEMPLATE_ID,CY,false",
-            "POSTAL, EMAIL,$POSTAL_EMAIL_SIGNATURE_WITH_REASONS_ENGLISH_TEMPLATE_ID,EN,true",
-            "POSTAL, LETTER,$POSTAL_LETTER_SIGNATURE_WITH_REASONS_ENGLISH_TEMPLATE_ID,EN,true",
-            "POSTAL, EMAIL,$POSTAL_EMAIL_SIGNATURE_WITH_REASONS_WELSH_TEMPLATE_ID,CY,true",
-            "POSTAL, LETTER,$POSTAL_LETTER_SIGNATURE_WITH_REASONS_WELSH_TEMPLATE_ID,CY,true",
-            "PROXY, EMAIL,$PROXY_EMAIL_SIGNATURE_WITH_REASONS_ENGLISH_TEMPLATE_ID,EN,true",
-            "PROXY, LETTER,$PROXY_LETTER_SIGNATURE_WITH_REASONS_ENGLISH_TEMPLATE_ID,EN,true",
-            "PROXY, EMAIL,$PROXY_EMAIL_SIGNATURE_WITH_REASONS_WELSH_TEMPLATE_ID,CY,true",
-            "PROXY, LETTER,$PROXY_LETTER_SIGNATURE_WITH_REASONS_WELSH_TEMPLATE_ID,CY,true"
+            "POSTAL, EMAIL,$POSTAL_EMAIL_SIGNATURE_ENGLISH_TEMPLATE_ID,EN,false,postal",
+            "POSTAL, LETTER,$POSTAL_LETTER_SIGNATURE_ENGLISH_TEMPLATE_ID,EN,false,postal",
+            "POSTAL, EMAIL,$POSTAL_EMAIL_SIGNATURE_WELSH_TEMPLATE_ID,CY,false,drwy'r post",
+            "POSTAL, LETTER,$POSTAL_LETTER_SIGNATURE_WELSH_TEMPLATE_ID,CY,false,drwy'r post",
+            "PROXY, EMAIL,$PROXY_EMAIL_SIGNATURE_ENGLISH_TEMPLATE_ID,EN,false,proxy",
+            "PROXY, LETTER,$PROXY_LETTER_SIGNATURE_ENGLISH_TEMPLATE_ID,EN,false,proxy",
+            "PROXY, EMAIL,$PROXY_EMAIL_SIGNATURE_WELSH_TEMPLATE_ID,CY,false,drwy ddirprwy",
+            "PROXY, LETTER,$PROXY_LETTER_SIGNATURE_WELSH_TEMPLATE_ID,CY,false,drwy ddirprwy",
+            "POSTAL, EMAIL,$POSTAL_EMAIL_SIGNATURE_WITH_REASONS_ENGLISH_TEMPLATE_ID,EN,true,postal",
+            "POSTAL, LETTER,$POSTAL_LETTER_SIGNATURE_WITH_REASONS_ENGLISH_TEMPLATE_ID,EN,true,postal",
+            "POSTAL, EMAIL,$POSTAL_EMAIL_SIGNATURE_WITH_REASONS_WELSH_TEMPLATE_ID,CY,true,drwy'r post",
+            "POSTAL, LETTER,$POSTAL_LETTER_SIGNATURE_WITH_REASONS_WELSH_TEMPLATE_ID,CY,true,drwy'r post",
+            "PROXY, EMAIL,$PROXY_EMAIL_SIGNATURE_WITH_REASONS_ENGLISH_TEMPLATE_ID,EN,true,proxy",
+            "PROXY, LETTER,$PROXY_LETTER_SIGNATURE_WITH_REASONS_ENGLISH_TEMPLATE_ID,EN,true,proxy",
+            "PROXY, EMAIL,$PROXY_EMAIL_SIGNATURE_WITH_REASONS_WELSH_TEMPLATE_ID,CY,true,drwy ddirprwy",
+            "PROXY, LETTER,$PROXY_LETTER_SIGNATURE_WITH_REASONS_WELSH_TEMPLATE_ID,CY,true,drwy ddirprwy"
         ]
     )
     fun `should return template preview given valid request`(
@@ -232,7 +232,8 @@ internal class GenerateRejectedSignatureTemplatePreviewIntegrationTest : Integra
         notificationChannel: NotificationChannel,
         templateId: String,
         language: Language,
-        withReasons: Boolean
+        withReasons: Boolean,
+        expectedPersonalisationSourceType: String,
     ) {
         // Given
         val notifyClientResponse = NotifyGenerateTemplatePreviewSuccessResponse(id = templateId)
@@ -279,7 +280,8 @@ internal class GenerateRejectedSignatureTemplatePreviewIntegrationTest : Integra
                 "eroAddressLine3" to eroContactDetails.address.town!!,
                 "eroAddressLine4" to eroContactDetails.address.area!!,
                 "eroAddressLine5" to eroContactDetails.address.locality!!,
-                "eroPostcode" to eroContactDetails.address.postcode
+                "eroPostcode" to eroContactDetails.address.postcode,
+                "sourceType" to expectedPersonalisationSourceType,
             )
         }
         wireMockService.verifyNotifyGenerateTemplatePreview(templateId, expectedPersonalisationDataMap)
@@ -288,14 +290,14 @@ internal class GenerateRejectedSignatureTemplatePreviewIntegrationTest : Integra
     @ParameterizedTest
     @CsvSource(
         value = [
-            "POSTAL,EMAIL,$POSTAL_EMAIL_SIGNATURE_WITH_REASONS_ENGLISH_TEMPLATE_ID,true,false",
-            "POSTAL,LETTER,$POSTAL_LETTER_SIGNATURE_WITH_REASONS_ENGLISH_TEMPLATE_ID,true,false",
-            "PROXY,EMAIL,$PROXY_EMAIL_SIGNATURE_WITH_REASONS_ENGLISH_TEMPLATE_ID,true,false",
-            "PROXY,LETTER,$PROXY_LETTER_SIGNATURE_WITH_REASONS_ENGLISH_TEMPLATE_ID,true,false",
-            "POSTAL,EMAIL,$POSTAL_EMAIL_SIGNATURE_WITH_REASONS_ENGLISH_TEMPLATE_ID,false,true",
-            "POSTAL,LETTER,$POSTAL_LETTER_SIGNATURE_WITH_REASONS_ENGLISH_TEMPLATE_ID,false,true",
-            "PROXY,EMAIL,$PROXY_EMAIL_SIGNATURE_WITH_REASONS_ENGLISH_TEMPLATE_ID,false,true",
-            "PROXY,LETTER,$PROXY_LETTER_SIGNATURE_WITH_REASONS_ENGLISH_TEMPLATE_ID,false,true"
+            "POSTAL,EMAIL,$POSTAL_EMAIL_SIGNATURE_WITH_REASONS_ENGLISH_TEMPLATE_ID,true,false,postal",
+            "POSTAL,LETTER,$POSTAL_LETTER_SIGNATURE_WITH_REASONS_ENGLISH_TEMPLATE_ID,true,false,postal",
+            "PROXY,EMAIL,$PROXY_EMAIL_SIGNATURE_WITH_REASONS_ENGLISH_TEMPLATE_ID,true,false,proxy",
+            "PROXY,LETTER,$PROXY_LETTER_SIGNATURE_WITH_REASONS_ENGLISH_TEMPLATE_ID,true,false,proxy",
+            "POSTAL,EMAIL,$POSTAL_EMAIL_SIGNATURE_WITH_REASONS_ENGLISH_TEMPLATE_ID,false,true,postal",
+            "POSTAL,LETTER,$POSTAL_LETTER_SIGNATURE_WITH_REASONS_ENGLISH_TEMPLATE_ID,false,true,postal",
+            "PROXY,EMAIL,$PROXY_EMAIL_SIGNATURE_WITH_REASONS_ENGLISH_TEMPLATE_ID,false,true,proxy",
+            "PROXY,LETTER,$PROXY_LETTER_SIGNATURE_WITH_REASONS_ENGLISH_TEMPLATE_ID,false,true,proxy"
         ]
     )
     fun `should return template preview given valid request when optional values are not populated`(
@@ -303,7 +305,8 @@ internal class GenerateRejectedSignatureTemplatePreviewIntegrationTest : Integra
         notificationChannel: NotificationChannel,
         templateId: String,
         populateRejectionReasons: Boolean,
-        populateRejectionNotes: Boolean
+        populateRejectionNotes: Boolean,
+        expectedPersonalisationSourceType: String,
     ) {
         // Given
         val notifyClientResponse = NotifyGenerateTemplatePreviewSuccessResponse(id = templateId)
@@ -334,7 +337,8 @@ internal class GenerateRejectedSignatureTemplatePreviewIntegrationTest : Integra
                 "eroAddressLine3" to "",
                 "eroAddressLine4" to "",
                 "eroAddressLine5" to "",
-                "eroPostcode" to eroContactDetails.address.postcode
+                "eroPostcode" to eroContactDetails.address.postcode,
+                "sourceType" to expectedPersonalisationSourceType,
             )
         }
 

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GenerateRequestedSignatureTemplatePreviewIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GenerateRequestedSignatureTemplatePreviewIntegrationTest.kt
@@ -200,14 +200,14 @@ internal class GenerateRequestedSignatureTemplatePreviewIntegrationTest : Integr
     @ParameterizedTest
     @CsvSource(
         value = [
-            "POSTAL, EMAIL,$POSTAL_EMAIL_SIGNATURE_ENGLISH_TEMPLATE_ID,EN",
-            "POSTAL, LETTER,$POSTAL_LETTER_SIGNATURE_ENGLISH_TEMPLATE_ID,EN",
-            "POSTAL, EMAIL,$POSTAL_EMAIL_SIGNATURE_WELSH_TEMPLATE_ID,CY",
-            "POSTAL, LETTER,$POSTAL_LETTER_SIGNATURE_WELSH_TEMPLATE_ID,CY",
-            "PROXY, EMAIL,$PROXY_EMAIL_SIGNATURE_ENGLISH_TEMPLATE_ID,EN",
-            "PROXY, LETTER,$PROXY_LETTER_SIGNATURE_ENGLISH_TEMPLATE_ID,EN",
-            "PROXY, EMAIL,$PROXY_EMAIL_SIGNATURE_WELSH_TEMPLATE_ID,CY",
-            "PROXY, LETTER,$PROXY_LETTER_SIGNATURE_WELSH_TEMPLATE_ID,CY",
+            "POSTAL, EMAIL,$POSTAL_EMAIL_SIGNATURE_ENGLISH_TEMPLATE_ID,EN,postal",
+            "POSTAL, LETTER,$POSTAL_LETTER_SIGNATURE_ENGLISH_TEMPLATE_ID,EN,postal",
+            "POSTAL, EMAIL,$POSTAL_EMAIL_SIGNATURE_WELSH_TEMPLATE_ID,CY,drwy'r post",
+            "POSTAL, LETTER,$POSTAL_LETTER_SIGNATURE_WELSH_TEMPLATE_ID,CY,drwy'r post",
+            "PROXY, EMAIL,$PROXY_EMAIL_SIGNATURE_ENGLISH_TEMPLATE_ID,EN,proxy",
+            "PROXY, LETTER,$PROXY_LETTER_SIGNATURE_ENGLISH_TEMPLATE_ID,EN,proxy",
+            "PROXY, EMAIL,$PROXY_EMAIL_SIGNATURE_WELSH_TEMPLATE_ID,CY,drwy ddirprwy",
+            "PROXY, LETTER,$PROXY_LETTER_SIGNATURE_WELSH_TEMPLATE_ID,CY,drwy ddirprwy",
         ]
     )
     fun `should return template preview given valid request`(
@@ -215,6 +215,7 @@ internal class GenerateRequestedSignatureTemplatePreviewIntegrationTest : Integr
         notificationChannel: NotificationChannel,
         templateId: String,
         language: Language,
+        expectedPersonalisationSourceType: String,
     ) {
         // Given
         val notifyClientResponse = NotifyGenerateTemplatePreviewSuccessResponse(id = templateId)
@@ -256,7 +257,8 @@ internal class GenerateRequestedSignatureTemplatePreviewIntegrationTest : Integr
                 "eroAddressLine3" to eroContactDetails.address.town!!,
                 "eroAddressLine4" to eroContactDetails.address.area!!,
                 "eroAddressLine5" to eroContactDetails.address.locality!!,
-                "eroPostcode" to eroContactDetails.address.postcode
+                "eroPostcode" to eroContactDetails.address.postcode,
+                "sourceType" to expectedPersonalisationSourceType,
             )
         }
         wireMockService.verifyNotifyGenerateTemplatePreview(templateId, expectedPersonalisationDataMap)
@@ -265,16 +267,17 @@ internal class GenerateRequestedSignatureTemplatePreviewIntegrationTest : Integr
     @ParameterizedTest
     @CsvSource(
         value = [
-            "POSTAL,EMAIL,$POSTAL_EMAIL_SIGNATURE_ENGLISH_TEMPLATE_ID",
-            "POSTAL,LETTER,$POSTAL_LETTER_SIGNATURE_ENGLISH_TEMPLATE_ID",
-            "PROXY,EMAIL,$PROXY_EMAIL_SIGNATURE_ENGLISH_TEMPLATE_ID",
-            "PROXY,LETTER,$PROXY_LETTER_SIGNATURE_ENGLISH_TEMPLATE_ID",
+            "POSTAL,EMAIL,$POSTAL_EMAIL_SIGNATURE_ENGLISH_TEMPLATE_ID,postal",
+            "POSTAL,LETTER,$POSTAL_LETTER_SIGNATURE_ENGLISH_TEMPLATE_ID,postal",
+            "PROXY,EMAIL,$PROXY_EMAIL_SIGNATURE_ENGLISH_TEMPLATE_ID,proxy",
+            "PROXY,LETTER,$PROXY_LETTER_SIGNATURE_ENGLISH_TEMPLATE_ID,proxy",
         ]
     )
     fun `should return template preview given valid request when optional values are not populated`(
         sourceType: SourceType,
         notificationChannel: NotificationChannel,
         templateId: String,
+        expectedPersonalisationSourceType: String,
     ) {
         // Given
         val notifyClientResponse = NotifyGenerateTemplatePreviewSuccessResponse(id = templateId)
@@ -302,7 +305,8 @@ internal class GenerateRequestedSignatureTemplatePreviewIntegrationTest : Integr
                 "eroAddressLine3" to "",
                 "eroAddressLine4" to "",
                 "eroAddressLine5" to "",
-                "eroPostcode" to eroContactDetails.address.postcode
+                "eroPostcode" to eroContactDetails.address.postcode,
+                "sourceType" to expectedPersonalisationSourceType,
             )
         }
 

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/dto/RejectedSignatureTemplatePreviewDtoBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/dto/RejectedSignatureTemplatePreviewDtoBuilder.kt
@@ -12,12 +12,14 @@ import uk.gov.dluhc.notificationsapi.testsupport.testdata.aValidApplicationRefer
 
 fun buildGenerateRejectedSignatureTemplatePreviewDto(
     channel: NotificationChannel = NotificationChannel.EMAIL,
+    sourceType: SourceType = SourceType.PROXY,
+    language: LanguageDto = LanguageDto.ENGLISH,
     personalisation: RejectedSignaturePersonalisationDto = buildRejectedSignaturePersonalisationDto(),
     notificationType: NotificationType = NotificationType.REJECTED_SIGNATURE,
 ) = RejectedSignatureTemplatePreviewDto(
     channel = channel,
-    sourceType = SourceType.PROXY,
-    language = LanguageDto.ENGLISH,
+    sourceType = sourceType,
+    language = language,
     personalisation = personalisation,
     notificationType = notificationType
 )
@@ -29,11 +31,13 @@ fun buildRejectedSignaturePersonalisationDto(
     rejectionNotes: String? = null,
     rejectionReasons: List<String> = emptyList(),
     rejectionFreeText: String? = null,
+    sourceType: String = "postal",
 ) = RejectedSignaturePersonalisationDto(
     applicationReference = applicationReference,
     firstName = firstName,
     eroContactDetails = eroContactDetails,
     rejectionNotes = rejectionNotes,
     rejectionReasons = rejectionReasons,
-    rejectionFreeText = rejectionFreeText
+    rejectionFreeText = rejectionFreeText,
+    sourceType = sourceType,
 )

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/dto/RequestedSignatureTemplatePreviewDtoBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/dto/RequestedSignatureTemplatePreviewDtoBuilder.kt
@@ -28,9 +28,11 @@ fun buildRequestedSignaturePersonalisationDto(
     firstName: String = DataFaker.faker.name().firstName(),
     eroContactDetails: ContactDetailsDto = buildContactDetailsDto(),
     freeText: String? = null,
+    sourceType: String = "postal",
 ) = RequestedSignaturePersonalisationDto(
     applicationReference = applicationReference,
     firstName = firstName,
     eroContactDetails = eroContactDetails,
     freeText = freeText,
+    sourceType = sourceType,
 )

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/dto/TemplatePersonalisationDtoBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/dto/TemplatePersonalisationDtoBuilder.kt
@@ -70,12 +70,14 @@ fun buildIdDocumentRequiredPersonalisationDto(
 fun buildApplicationReceivedPersonalisationDto(
     applicationReference: String = aValidApplicationReference(),
     firstName: String = faker.name().firstName(),
-    eroContactDetails: ContactDetailsDto = buildContactDetailsDto()
+    eroContactDetails: ContactDetailsDto = buildContactDetailsDto(),
+    sourceType: String = "postal",
 ): ApplicationReceivedPersonalisationDto =
     ApplicationReceivedPersonalisationDto(
         applicationReference = applicationReference,
         firstName = firstName,
-        eroContactDetails = eroContactDetails
+        eroContactDetails = eroContactDetails,
+        sourceType = sourceType,
     )
 
 fun buildApplicationApprovedPersonalisationDto(
@@ -94,14 +96,16 @@ fun buildRejectedDocumentPersonalisationDto(
     firstName: String = faker.name().firstName(),
     rejectedDocumentFreeText: String? = faker.harryPotter().spell(),
     documents: List<String> = listOf(faker.lordOfTheRings().location()),
-    eroContactDetails: ContactDetailsDto = buildContactDetailsDto()
+    eroContactDetails: ContactDetailsDto = buildContactDetailsDto(),
+    sourceType: String = "postal",
 ): RejectedDocumentPersonalisationDto =
     RejectedDocumentPersonalisationDto(
         applicationReference = applicationReference,
         firstName = firstName,
         documents = documents,
         rejectedDocumentFreeText = rejectedDocumentFreeText,
-        eroContactDetails = eroContactDetails
+        eroContactDetails = eroContactDetails,
+        sourceType = sourceType,
     )
 
 fun buildPhotoPersonalisationDtoFromMessage(
@@ -200,35 +204,6 @@ fun buildIdDocumentRequiredPersonalisationDtoFromMessage(
     }
 }
 
-fun buildApplicationReceivedPersonalisationDtoFromMessage(
-    personalisationMessage: BasePersonalisation
-): ApplicationReceivedPersonalisationDto {
-    return with(personalisationMessage) {
-        ApplicationReceivedPersonalisationDto(
-            applicationReference = applicationReference,
-            firstName = firstName,
-            eroContactDetails = with(eroContactDetails) {
-                buildContactDetailsDto(
-                    localAuthorityName = localAuthorityName,
-                    website = website,
-                    phone = phone,
-                    email = email,
-                    address = with(address) {
-                        buildAddressDto(
-                            street = street,
-                            property = property,
-                            locality = locality,
-                            town = town,
-                            area = area,
-                            postcode = postcode,
-                        )
-                    }
-                )
-            }
-        )
-    }
-}
-
 fun buildApplicationApprovedPersonalisationDtoFromMessage(
     personalisationMessage: BasePersonalisation
 ): ApplicationApprovedPersonalisationDto {
@@ -296,9 +271,10 @@ fun buildIdDocumentRequiredPersonalisationMapFromDto(
 
 fun buildApplicationReceivedPersonalisationMapFromDto(
     personalisationDto: ApplicationReceivedPersonalisationDto = buildApplicationReceivedPersonalisationDto(),
-): Map<String, String> {
+): Map<String, Any> {
     val personalisationMap = mutableMapOf<String, String>()
     with(personalisationDto) {
+        personalisationMap["sourceType"] = sourceType
         personalisationMap.putAll(getCommonDetailsMap(firstName, applicationReference, eroContactDetails))
     }
     return personalisationMap
@@ -331,6 +307,7 @@ fun buildRejectedDocumentPersonalisationMapFromDto(
     with(personalisationDto) {
         personalisationMap["rejectedDocuments"] = documents
         personalisationMap["rejectionMessage"] = rejectedDocumentFreeText ?: ""
+        personalisationMap["sourceType"] = sourceType
         personalisationMap.putAll(getCommonDetailsMap(firstName, applicationReference, eroContactDetails))
     }
     return personalisationMap
@@ -344,6 +321,7 @@ fun buildRejectedSignaturePersonalisationMapFromDto(
         personalisationMap["rejectionNotes"] = rejectionNotes ?: ""
         personalisationMap["rejectionReasons"] = rejectionReasons
         personalisationMap["rejectionFreeText"] = rejectionFreeText ?: ""
+        personalisationMap["sourceType"] = sourceType
         personalisationMap.putAll(getCommonDetailsMap(firstName, applicationReference, eroContactDetails))
     }
     return personalisationMap
@@ -355,6 +333,7 @@ fun buildRequestedSignaturePersonalisationMapFromDto(
     val personalisationMap = mutableMapOf<String, Any>()
     with(personalisationDto) {
         personalisationMap["freeText"] = freeText ?: ""
+        personalisationMap["sourceType"] = sourceType
         personalisationMap.putAll(getCommonDetailsMap(firstName, applicationReference, eroContactDetails))
     }
     return personalisationMap
@@ -402,12 +381,14 @@ fun buildNinoNotMatchedPersonalisationDto(
     applicationReference: String = aValidApplicationReference(),
     firstName: String = faker.name().firstName(),
     eroContactDetails: ContactDetailsDto = buildContactDetailsDto(),
-    additionalNotes: String? = "Additional Notes"
+    additionalNotes: String? = "Additional Notes",
+    sourceType: String = "postal",
 ): NinoNotMatchedPersonalisationDto = NinoNotMatchedPersonalisationDto(
     firstName = firstName,
     eroContactDetails = eroContactDetails,
     applicationReference = applicationReference,
-    additionalNotes = additionalNotes
+    additionalNotes = additionalNotes,
+    sourceType = sourceType,
 )
 
 fun buildNinoNotMatchedPersonalisationMapFromDto(

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,12 +1,110 @@
 # GOV.UK Notify Templates
 
-Notification API provides a proxy to the [UK Government Notify service](https://www.notifications.service.gov.uk/), which handles the sending of various
-communications by email, text or letter. The full documentation around the can be found [here](https://www.notifications.service.gov.uk/using-notify/api-documentation).
+Notification API provides a proxy to the [UK Government Notify service](https://www.notifications.service.gov.uk/), 
+which handles the sending of various communications by email, text or letter. The full documentation on the service can 
+be found [here](https://www.notifications.service.gov.uk/using-notify/api-documentation).
 
-Once you have been given access you will be able to see the templates that are already defined, edit them and create new ones.
-The template ids are then referenced by Notifications API via environment variables mapped to properties in `application.yml`.
+Once you have been given access to GOV Notify, you will be able to see the templates that are already defined, edit 
+them and create new ones. 
 
-## Template Preview - Notification API Response
+The template ids are referenced by Notifications API via environment variables set in the infra repo and mapped to 
+properties in `application.yml`.
+
+_**Please be aware that templates for live services are stored on the site!**_
+
+## Template Versioning
+
+Template versioning is not currently supported by GOV Notify, and templates can only be created through their website's
+UI. In order to allow for control over template changes, especially when breaking changes are introduced, all 
+templates should include a version number in their name e.g.
+
+    Rejected Documents Email - EN - v1.0
+
+When a template requires a breaking change (e.g. addition of a new placeholder), then a new copy of the template should
+be created and the version number incremented. This allows for controlled rollout as we can switch to the new template
+after the required service changes have already been deployed.
+
+## Formatting templates
+
+Notify Service templates support following formatting options:
+
+    To put a title in your template, use a hash:
+    # This is a title
+    ## This is a subtitle (there is no difference to normal text for letters)
+
+    To make bullet points, use asterisks (sub-bullet points have two spaces before the asterisk):
+    * point 1
+    * point 2
+      * subpoint 2.1
+      * subpoint 2.2
+    * point 3
+      
+    To add inset text, use a caret:
+    ^ You must tell us if your circumstances change
+
+    To add a horizontal line, use three dashes:
+    First paragraph
+    ---
+    Second paragraph
+
+Note that you **cannot** bold text.
+
+[Documentation on formatting](https://www.notifications.service.gov.uk/using-notify/formatting#bullets)
+
+## Placeholders
+
+Placeholders are denoted with double brackets in the templates `((example))`. Adding the key `example` to the 
+personalisation dictionary will insert `example`'s value into the generated template in place of ((example)).
+
+### Missing Placeholders
+
+Requesting a template preview or attempting to send a notification without a placeholder causes the Notify service to 
+return a 400 Bad Request with response body:
+
+    {
+        "timestamp": "2022-12-22T11:20:51.681Z",
+        "status": 400,
+        "error": "Bad Request",
+        "message": "Status code: 400 {\"errors\":[{\"error\":\"BadRequestError\",\"message\":\"Missing personalisation: missingPlaceholder\"}],\"status_code\":400}\n"
+    }
+
+You can, however, send the empty string for a placeholder you do not wish to appear in the template (e.g. for optional
+text). This will create an empty line as shown in the example request and output below:
+
+    Template includes ERO Address as:
+    ((eroAddressLine1))
+    ((eroAddressLine2))
+    ((eroAddressLine3))
+    ((eroAddressLine4))
+    ((eroAddressPostcode))
+    
+    Request sent to Notify service includes blank values like:
+        "address": {
+            "property": "Some Property",
+            "street": "Charles Lane Street in bullets",
+            "town": "",
+            "area": "",
+            "postcode": "PE3 6SB"
+        }
+
+![template_img.png](template_img.png)
+
+Note that insets are still rendered if an empty string is provided, so use them sparingly.
+
+### Extra Placeholders
+
+Requesting a template preview or sending a notification with a placeholder that is not used in the template does not 
+cause any validation errors. This could be useful if we ever need to edit an existing template with new placeholders; 
+we can send the placeholder in advance and then update the template.
+
+
+### Placeholder Markup
+
+Markup within placeholder values is supported and changes the rendered HTML. Generally formatting would be expected 
+to be part of the template and not the placeholders. 
+
+## API Details
+### Template Preview - Notification API Response
 
 Notifications REST API has an endpoint described in Open API as:
 
@@ -28,52 +126,7 @@ Notifications REST API has an endpoint described in Open API as:
     example: <p>Hi Fred Blogs,</p>Html preview of the template with personalisation data, if the template supports html format
 
 
-Notify Service templates support following formatting options:
-
-    Formatting
-    To put a title in your template, use a hash:
-
-    # This is a title
-    To make bullet points, use asterisks:
-
-    * point 1
-    * point 2
-    * point 3
-      To add inset text, use a caret:
-
-    ^ You must tell us if your circumstances change
-    To add a horizontal line, use three dashes:
-
-    First paragraph
-
-    ---
-
-    Second paragraph
-
-
-Following section is the above details inserted as Mark up:
-
-Formatting
-To put a title in your template, use a hash:
-
-# This is a title
-
-To make bullet points, use asterisks:
-
-* point 1
-* point 2
-* point 3 To add inset text, use a caret:
-
-^ You must tell us if your circumstances change
-To add a horizontal line, use three dashes:
-
-First paragraph
-
----
-
-Second paragraph
-
-## Sent Message - Notification API Available Data
+### Sent Message - Notification API Available Data
 
 Notify send an email API returns a SendEmailResponse that is stored in the DynamoDB along with details of the request including personalisation contents.
 
@@ -103,7 +156,7 @@ Notify send an email API returns a SendEmailResponse that is stored in the Dynam
         "type": "PHOTO_RESUBMISSION"
     }
 
-It should be noted that **ALL** the details returned from the Notify service is included in the above item, the Java client response object has properties:
+It should be noted that **ALL** the details returned from the Notify service are included in the above item, the Java client response object has properties:
 
     public class SendEmailResponse {
     private final UUID notificationId;
@@ -130,130 +183,5 @@ It should be noted that **ALL** the details returned from the Notify service is 
         }
     }
 
-All request placeholders are saved as is the templateId used for sending so would be possible to use the generateTemplatePreview for a sent notification.
-
-Alternatively whilst sending an email the generate Template Preview can be called and its HTML stored alongside the sent details.
-
-## Missing Placeholder
-
-Requesting a template preview or attempting to send a notification without a placeholder causes the Notify service to return a 400 Bad Request with response body:
-
-    {
-        "timestamp": "2022-12-22T11:20:51.681Z",
-        "status": 400,
-        "error": "Bad Request",
-        "message": "Status code: 400 {\"errors\":[{\"error\":\"BadRequestError\",\"message\":\"Missing personalisation: missingPlaceholder\"}],\"status_code\":400}\n"
-    }
-
-
-## Extra Placeholder
-
-Requesting a template preview or sending a notification with a placeholder that is not used in the template does not cause any validation error and the template/send operation completes successfully.  This could be useful if we ever need to edit and existing template with new placeholders, we can send the placeholder in advance and then update the template.
-
-
-## Placeholder Markup
-
-UK Gov Notify service templates support a limited amount of mark up as detailed above.  Including markup with the placeholder values is supported and changes the rendered HTML, for example `# Creates a title  and * makes placeholder a bullet`.  Generally formatting would be expected to be part of the template and not the placeholders - after some trials the formatting was not reliable in placeholders.  Probably safest to avoid using titles and bullets in a free form text placeholder.  The undocumented ** syntax for bold, e.g.  &ast;&ast;Fred&ast;&ast; did not work - translated template included the **  as text.
-
-Example Request
-
-    {
-        "channel": "email",
-        "language": "en",
-        "personalisation": {
-            "applicationReference": "A3JSZC4CRH",
-            "firstName": "**Fred**",
-            "photoRequestFreeText": "Please provide a clear image",
-            "uploadPhotoLink": "helloworld",
-            "eroContactDetails": {
-                "localAuthorityName": "City of Sunderland",
-                "website": "not good",
-                "phone": "01234 567890",
-                "email": "fred.blogs@some-domain.co.uk",
-                "address": {
-                    "street": "This is a title Charles Lane Street",
-                    "property": "* Some Property",
-                    "locality": "* Some locality",
-                    "town": "* London",
-                    "area": "* Charles Area",
-                    "postcode": "# PE3 6SB"
-                }
-            }
-        }
-    }
-
-
-
-
-## Placeholder HTML
-
-Sent request with HTML formatting tags for paragraph, bold, strong, emphasis and list item:
-
-    {
-        "channel": "email",
-        "language": "en",
-        "personalisation": {
-            "applicationReference": "A3JSZC4CRH",
-            "firstName": "<b>Fred</b>",
-            "photoRequestFreeText": "<p>Please provide a clear image</p>",
-            "uploadPhotoLink": "helloworld",
-            "eroContactDetails": {
-                "localAuthorityName": "City of Sunderland",
-                "website": "not good",
-                "phone": "01234 567890",
-                "email": "fred.blogs@some-domain.co.uk",
-                "address": {
-                    "street": "This is a title Charles Lane Street",
-                    "property": "<li>Some Property</li>",
-                    "locality": "<em>Some locality</em>",
-                    "town": "<strong>London</strong>",
-                    "area": "<em>Charles Area</em>",
-                    "postcode": "PE3 6SB"
-                }
-            }
-        }
-    }
-
-The placeholder value is escaped in the rendered HTML and therefore appears as it does in the placeholder, for example "<em>Charles Area</em>" is in the HTML as `&amp;lt;em&amp;gt;Charles Area&amp;lt;/em&amp;gt;`
-
-
-
-
-## Blank Placeholders
-
-As documented in section 3 all placeholders MUST be included in a request so values that are not known are sent as blank strings (not null values).
-
-    Template includes ERO Address as:
-    ((eroAddressLine1))
-    ((eroAddressLine2))
-    ((eroAddressLine3))
-    ((eroAddressLine4))
-    ((eroAddressPostcode))
-    
-    Request sent to Notify service includes blank values like:
-        "address": {
-            "property": "Some Property",
-            "street": "Charles Lane Street in bullets",
-            "town": "",
-            "area": "",
-            "postcode": "PE3 6SB"
-        }
-
-
-
-
-The HTML returned will render with an empty line between address and postcode as below:
-
-![template_img.png](template_img.png)
-
-## Template Versioning
-
-Template versioning is not currently supported.
-In order to allow for control over template changes and specifically when breaking changes are introduced all templates
-should now include a version number in the name e.g.
-    
-    Rejected Documents Email - EN - v1.0
-
-When a template requires a breaking change (e.g. addition of a new placeholder) then a new copy of the template should
-be created and the version number incremented. This will then allow for controlled rollout by allowing the new template id
-to be specified after the required service changes have already been deployed.
+All request placeholders are saved, as is the templateId used, so would be possible to generate a preview for a 
+notification that has been sent.


### PR DESCRIPTION
## Ticket

https://technologyprogramme.atlassian.net/browse/EIP1-7146

## Summary

The new OAVA comms templates are identical minus some substitutions of "postal" and "proxy". I've created a single set of shared templates. This PR includes changes to make the "postal"/"proxy" substitutions, and also fixes some formatting issues with the rejected documents templates.

Apologies for some of the diffs being the inclusion of commas, I missed them when removing some changes.