### PR TITLE
EROPSPT-194

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,10 +20,14 @@ api:
           photo-resubmission-with-reasons-welsh: ${TEMPLATE_PHOTO_RESUBMISSION_WITH_REASONS_EMAIL_WELSH}
           id-document-resubmission-english: ${TEMPLATE_ID_DOCUMENT_RESUBMISSION_EMAIL_ENGLISH}
           id-document-resubmission-welsh: ${TEMPLATE_ID_DOCUMENT_RESUBMISSION_EMAIL_WELSH}
-          id-document-resubmission-with-reasons-english: ${TEMPLATE_ID_DOCUMENT_RESUBMISSION_WITH_REASONS_EMAIL_ENGLISH}
-          id-document-resubmission-with-reasons-welsh: ${TEMPLATE_ID_DOCUMENT_RESUBMISSION_WITH_REASONS_EMAIL_WELSH}
           id-document-required-english: ${TEMPLATE_ID_DOCUMENT_REQUIRED_EMAIL_ENGLISH}
           id-document-required-welsh: ${TEMPLATE_ID_DOCUMENT_REQUIRED_EMAIL_WELSH}
+
+          # Rejection reasons have not yet been fully implemented for VAC.
+          # Until the full journey for selecting rejection reasons has been implemented we shouldn't send them in emails.
+          id-document-resubmission-with-reasons-english: ${TEMPLATE_ID_DOCUMENT_RESUBMISSION_EMAIL_ENGLISH}
+          id-document-resubmission-with-reasons-welsh: ${TEMPLATE_ID_DOCUMENT_RESUBMISSION_EMAIL_WELSH}
+
         letter:
           rejected-english: ${TEMPLATE_APPLICATION_REJECTED_LETTER_ENGLISH}
           rejected-welsh: ${TEMPLATE_APPLICATION_REJECTED_LETTER_WELSH}
@@ -33,10 +37,14 @@ api:
           photo-resubmission-with-reasons-welsh: ${TEMPLATE_PHOTO_RESUBMISSION_WITH_REASONS_LETTER_WELSH}
           id-document-resubmission-english: ${TEMPLATE_ID_DOCUMENT_RESUBMISSION_LETTER_ENGLISH}
           id-document-resubmission-welsh: ${TEMPLATE_ID_DOCUMENT_RESUBMISSION_LETTER_WELSH}
-          id-document-resubmission-with-reasons-english: ${TEMPLATE_ID_DOCUMENT_RESUBMISSION_WITH_REASONS_LETTER_ENGLISH}
-          id-document-resubmission-with-reasons-welsh: ${TEMPLATE_ID_DOCUMENT_RESUBMISSION_WITH_REASONS_LETTER_WELSH}
           id-document-required-english: ${TEMPLATE_ID_DOCUMENT_REQUIRED_LETTER_ENGLISH}
           id-document-required-welsh: ${TEMPLATE_ID_DOCUMENT_REQUIRED_LETTER_WELSH}
+
+          # Rejection reasons have not yet been fully implemented for VAC.
+          # Until the full journey for selecting rejection reasons has been implemented we shouldn't send them in emails.
+          id-document-resubmission-with-reasons-english: ${TEMPLATE_ID_DOCUMENT_RESUBMISSION_LETTER_ENGLISH}
+          id-document-resubmission-with-reasons-welsh: ${TEMPLATE_ID_DOCUMENT_RESUBMISSION_WITH_REASONS_LETTER_WELSH}
+
       postal:
         email:
           received-english: ${TEMPLATE_POSTAL_APPLICATION_RECEIVED_EMAIL_ENGLISH}


### PR DESCRIPTION
Do not use ID_DOCUMENT_RESUBMISSION_WITH_REASONS template for VAC applications until reasons can be selected on the frontend. Currently the reason is always submitted as "document is too old" but the ERO has no way to see that or change it to an accurate reason. We should update the frontend to let users choose rejection reasons, but in the meantime we should not include it in communications.